### PR TITLE
[libretro] merge cheat support changes

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -232,6 +232,7 @@ else ifeq ($(platform), ngc)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	ENDIANNESS_DEFINES := -DBYTE_ORDER=BIG_ENDIAN
 	PLATFORM_DEFINES := -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -DALT_RENDER
+	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	STATIC_LINKING = 1
 
 # Nintendo Wii
@@ -240,15 +241,17 @@ else ifeq ($(platform), wii)
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	PLATFORM_DEFINES := -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -DALT_RENDER
+	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	ENDIANNESS_DEFINES := -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 
-# Nintendo Wii
+# Nintendo WiiU
 else ifeq ($(platform), wiiu)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-	PLATFORM_DEFINES := -DGEKKO -DWIIU -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -DALT_RENDER -DUSE_DYNAMIC_ALLOC
+	PLATFORM_DEFINES := -DGEKKO -DWIIU -DHW_RVL -mwup -mcpu=750 -meabi -mhard-float -DALT_RENDER -DUSE_DYNAMIC_ALLOC
+	PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 	ENDIANNESS_DEFINES := -DBYTE_ORDER=BIG_ENDIAN
 	STATIC_LINKING = 1
 

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1926,12 +1926,15 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 bool retro_load_game(const struct retro_game_info *info)
 {
    int i;
-   const char *dir;
+   const char *dir = NULL;
 #if defined(_WIN32)
-   char slash = '\\';
+   char slash      = '\\';
 #else
-   char slash = '/';
+   char slash      = '/';
 #endif
+
+   if (!info)
+      return false;
 
    extract_directory(g_rom_dir, info->path, sizeof(g_rom_dir));
    extract_name(g_rom_name, info->path, sizeof(g_rom_name));


### PR DESCRIPTION
This seems to add support for non-standard Action Replay and Game Genie cheat code formats for Master System (00xx-xxyy, xxxx:yy and shortened ABC-DEF instead of just 00xxxx:yy and ABC-DEF-GHI that were already supported). Not a good idea in my opinion to re-invent standards and adapt emulators every time a new format is invented by someone but I guess it's too late now.

Also adds support for "multiline" cheat format used in retroarch ( basically it's just cheat codes put on the same line for some unknown reason)