### PR TITLE
[Core/State] Up the version number because of PSG core rewrite

### DIFF
--- a/core/state.h
+++ b/core/state.h
@@ -40,7 +40,7 @@
 #define _STATE_H_
 
 #define STATE_SIZE    0xfd000
-#define STATE_VERSION "GENPLUS-GX 1.7.5"
+#define STATE_VERSION "GENPLUS-GX 1.8.0"
 
 #define load_param(param, size) \
   memcpy(param, &state[bufferptr], size); \


### PR DESCRIPTION
This avoids core crashes when loading old savestates.