### PR TITLE
[Core/Sound] Nuked OPN2: removed discrete ym3438 core

### DIFF
--- a/core/sound/ym3438.c
+++ b/core/sound/ym3438.c
@@ -40,7 +40,7 @@
  *      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
  *          OPL2 ROMs.
  *
- * version: 1.0.7
+ * version: 1.0.8
  */
 
 #include <string.h>
@@ -233,7 +233,7 @@ static const Bit32u fm_algorithm[4][6][8] = {
     }
 };
 
-static Bit32u chip_type = ym3438_type_discrete;
+static Bit32u chip_type = ym3438_mode_readmode;
 
 void OPN2_DoIO(ym3438_t *chip)
 {
@@ -995,7 +995,7 @@ void OPN2_ChOutput(ym3438_t *chip)
     chip->mol = 0;
     chip->mor = 0;
 
-    if (chip_type == ym3438_type_ym2612)
+    if (chip_type & ym3438_mode_ym2612)
     {
         out_en = ((cycles & 3) == 3) || test_dac;
         /* YM2612 DAC emulation(not verified) */
@@ -1028,11 +1028,6 @@ void OPN2_ChOutput(ym3438_t *chip)
     else
     {
         out_en = ((cycles & 3) != 0) || test_dac;
-        /* Discrete YM3438 seems has the ladder effect too */
-        if (out >= 0 && chip_type == ym3438_type_discrete)
-        {
-            out++;
-        }
         if (chip->ch_lock_l && out_en)
         {
             chip->mol = out;
@@ -1397,7 +1392,7 @@ Bit32u OPN2_ReadIRQPin(ym3438_t *chip)
 
 Bit8u OPN2_Read(ym3438_t *chip, Bit32u port)
 {
-    if ((port & 3) == 0 || chip_type == ym3438_type_asic)
+    if ((port & 3) == 0 || (chip_type & ym3438_mode_readmode))
     {
         if (chip->mode_test_21[6])
         {
@@ -1426,7 +1421,7 @@ Bit8u OPN2_Read(ym3438_t *chip, Bit32u port)
             chip->status = (chip->busy << 7) | (chip->timer_b_overflow_flag << 1)
                  | chip->timer_a_overflow_flag;
         }
-        if (chip_type == ym3438_type_ym2612)
+        if (chip_type & ym3438_mode_ym2612)
         {
             chip->status_time = 300000;
         }

--- a/core/sound/ym3438.h
+++ b/core/sound/ym3438.h
@@ -39,16 +39,15 @@
  *      OPLx decapsulated(Matthew Gambrell, Olli Niemitalo):
  *          OPL2 ROMs.
  *
- * version: 1.0.7
+ * version: 1.0.8
  */
 
 #ifndef YM3438_H
 #define YM3438_H
 
 enum {
-    ym3438_type_discrete = 0,   /* Discrete YM3438 (Teradrive)          */
-    ym3438_type_asic = 1,       /* ASIC YM3438 (MD1 VA7, MD2, MD3, etc) */
-    ym3438_type_ym2612 = 2      /* YM2612 (MD1, MD2 VA2)                */
+    ym3438_mode_ym2612 = 0x01,      /* Enables YM2612 emulation (MD1, MD2 VA2) */
+    ym3438_mode_readmode = 0x02,    /* Enables status read on any port (TeraDrive, MD1 VA7, MD2, etc) */
 };
 
 #include <stdint.h>

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -1156,18 +1156,13 @@ static void check_variables(void)
     orig_value = config.ym3438;
     if (!strcmp(var.value, "nuked (ym2612)"))
     {
-      OPN2_SetChipType(ym3438_type_ym2612);
+      OPN2_SetChipType(ym3438_mode_ym2612);
       config.ym3438 = 1;
     }
-    else if (!strcmp(var.value, "nuked (asic ym3438)"))
+    else if (!strcmp(var.value, "nuked (ym3438)"))
     {
-      OPN2_SetChipType(ym3438_type_asic);
+      OPN2_SetChipType(ym3438_mode_readmode);
       config.ym3438 = 2;
-    }
-    else if (!strcmp(var.value, "nuked (discrete ym3438)"))
-    {
-      OPN2_SetChipType(ym3438_type_discrete);
-      config.ym3438 = 3;
     }
     else
     {
@@ -1766,7 +1761,7 @@ void retro_set_environment(retro_environment_t cb)
       { "genesis_plus_gx_lock_on", "Cartridge lock-on; disabled|game genie|action replay (pro)|sonic & knuckles" },
       { "genesis_plus_gx_ym2413", "Master System FM (YM2413); auto|disabled|enabled" },
 #ifdef HAVE_YM3438_CORE
-      { "genesis_plus_gx_ym2612", "Mega Drive / Genesis FM; mame (ym2612)|mame (asic ym3438)|mame (enhanced ym3438)|nuked (ym2612)|nuked (asic ym3438)|nuked (discrete ym3438)" },
+      { "genesis_plus_gx_ym2612", "Mega Drive / Genesis FM; mame (ym2612)|mame (asic ym3438)|mame (enhanced ym3438)|nuked (ym2612)|nuked (ym3438)" },
 #else
       { "genesis_plus_gx_ym2612", "Mega Drive / Genesis FM; mame (ym2612)|mame (asic ym3438)|mame (enhanced ym3438)" },
 #endif


### PR DESCRIPTION
Apparently YM3438 on Sega TeraDrive behaves and sounds exactly like ASIC one, so there's no more point to have this option anymore.