### PR TITLE
[Wii] Allow loading SMS, GG, SG1000, and Sega CD roms from command line arguments

### DIFF
--- a/gx/main.c
+++ b/gx/main.c
@@ -488,8 +488,21 @@ int main (int argc, char *argv[])
     /* automatically load any file passed as argument */
     autoload = 1;
 
+    /* Guess rom type */
+    u8 romtype = 0;
+    const char* extension = strrchr(argv[2], '.');
+    if (extension == NULL) {
+      extension = ".gen";
+    }
+
+    if (strcasecmp(extension, ".iso") == 0) romtype = 1;
+    else if (strcasecmp(extension, ".cue") == 0) romtype = 1;
+    else if (strcasecmp(extension, ".sms") == 0) romtype = 2;
+    else if (strcasecmp(extension, ".gg") == 0) romtype = 3;
+    else if (strcasecmp(extension, ".sg") == 0) romtype = 4;
+
     /* add the file to the top of the history. */
-    history_add_file(argv[1], argv[2], 0);
+    history_add_file(argv[1], argv[2], romtype);
   }
 
   /* automatically load first file from history list if requested */


### PR DESCRIPTION
The command line arguments are primarily for loaders like Wiiflow, but I use them to load ROMs directly from the Homebrew Channel. It already works for Genesis ROMs; this allows it to work for other systems' ROMs too, as long as the file extension is correct.

Tested with this meta.xml:

	<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
	<app version="1">
	  <name>Sonic Triple Trouble</name>
	  <coder></coder>
	  <version></version>
	  <release_date></release_date>
	  <short_description> </short_description> 
	  <long_description> </long_description> 
	  <arguments>
		<arg>sd:/apps/tripletrouble/</arg>
		<arg>tripletrouble.gg</arg>
	  </arguments>
	  <ahb_access/>
	</app>