### PR TITLE
Build fix

### DIFF
--- a/core/z80/z80.c
+++ b/core/z80/z80.c
@@ -467,12 +467,12 @@ static const funcptr tablename[0x100] = {  \
   prefix##_f8,prefix##_f9,prefix##_fa,prefix##_fb,prefix##_fc,prefix##_fd,prefix##_fe,prefix##_ff  \
 }
 
-PROTOTYPES(Z80op,op);
-PROTOTYPES(Z80cb,cb);
-PROTOTYPES(Z80dd,dd);
-PROTOTYPES(Z80ed,ed);
-PROTOTYPES(Z80fd,fd);
-PROTOTYPES(Z80xycb,xycb);
+PROTOTYPES(Z80op,op)
+PROTOTYPES(Z80cb,cb)
+PROTOTYPES(Z80dd,dd)
+PROTOTYPES(Z80ed,ed)
+PROTOTYPES(Z80fd,fd)
+PROTOTYPES(Z80xycb,xycb)
 
 #ifndef BIG_SWITCH
 FUNCTABLE(Z80op,op);


### PR DESCRIPTION
With gcc-8.2.1 on Fedora29, there are the errors below.

../core/z80/z80.c:470:21: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80op,op);
                     ^
../core/z80/z80.c:471:21: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80cb,cb);
                     ^
../core/z80/z80.c:472:21: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80dd,dd);
                     ^
../core/z80/z80.c:473:21: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80ed,ed);
                     ^
../core/z80/z80.c:474:21: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80fd,fd);
                     ^
../core/z80/z80.c:475:25: error: ISO C does not allow extra ';' outside of a function [-Wpedantic]
 PROTOTYPES(Z80xycb,xycb);
                         ^
make: *** [Makefile.sdl2:183: build_sdl2/z80.o] Error 1