### PR TITLE
Fixed extra #ifdef token warning in sound.c

### DIFF
--- a/core/sound/sound.c
+++ b/core/sound/sound.c
@@ -44,7 +44,7 @@
 #define YM2612_CLOCK_RATIO (7*6)
 
 /* FM output buffer (large enough to hold a whole frame at original chips rate) */
-#ifdef HAVE_YM3438_CORE || HAVE_OPLL_CORE
+#if defined(HAVE_YM3438_CORE) || defined(HAVE_OPLL_CORE)
 static int fm_buffer[1080 * 2 * 24];
 #else
 static int fm_buffer[1080 * 2];


### PR DESCRIPTION
This fixes:
core/sound/sound.c:47:25: warning: extra tokens at end of #ifdef directive
   47 | #ifdef HAVE_YM3438_CORE || HAVE_OPLL_CORE