### PR TITLE
Use generated headers

### DIFF
--- a/Makefile.gc
+++ b/Makefile.gc
@@ -124,22 +124,22 @@ $(OUTPUT).elf: $(OFILES)
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the various extension
 #---------------------------------------------------------------------------------
-%.jpg.o	:	%.jpg
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.jpg.o	%_jpg.h :	%.jpg
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
 
-%.png.o	:	%.png
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.png.o	%_png.h :	%.png
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
-%.pcm.o	:	%.pcm
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.pcm.o	%_pcm.h :	%.pcm
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
-%.ogg.o	:	%.ogg
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.ogg.o	%_ogg.h :	%.ogg
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
 -include $(DEPENDS)
 

--- a/Makefile.gc
+++ b/Makefile.gc
@@ -77,10 +77,13 @@ else
 	export LD	:=	$(CXX)
 endif
 
-export OFILES	:=	$(addsuffix .o,$(BINFILES)) \
-			$(PNGFILES:.png=.png.o) $(PCMFILES:.pcm=.pcm.o) $(OGGFILES:.ogg=.ogg.o) \
-			$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) \
-			$(sFILES:.s=.o) $(SFILES:.S=.o)
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES)) \
+			$(PNGFILES:.png=.png.o) $(PCMFILES:.pcm=.pcm.o) $(OGGFILES:.ogg=.ogg.o)
+
+export OFILES_SOURCES := $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(sFILES:.s=.o) $(SFILES:.S=.o)
+export OFILES := $(OFILES_BIN) $(OFILES_SOURCES)
+
+export HFILES := $(addsuffix .h,$(subst .,_,$(BINFILES)))
 
 #---------------------------------------------------------------------------------
 # build a list of include paths
@@ -120,6 +123,8 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 $(OUTPUT).dol: $(OUTPUT).elf
 $(OUTPUT).elf: $(OFILES)
+
+$(OFILES_SOURCES) : $(HFILES)
 
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the various extension

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -81,10 +81,13 @@ else
 	export LD	:=	$(CXX)
 endif
 
-export OFILES	:=	$(addsuffix .o,$(BINFILES)) \
-			$(PNGFILES:.png=.png.o) $(PCMFILES:.pcm=.pcm.o) $(OGGFILES:.ogg=.ogg.o) \
-			$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) \
-			$(sFILES:.s=.o) $(SFILES:.S=.o)
+export OFILES_BIN	:=	$(addsuffix .o,$(BINFILES)) \
+			$(PNGFILES:.png=.png.o) $(PCMFILES:.pcm=.pcm.o) $(OGGFILES:.ogg=.ogg.o)
+
+export OFILES_SOURCES := $(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(sFILES:.s=.o) $(SFILES:.S=.o)
+export OFILES := $(OFILES_BIN) $(OFILES_SOURCES)
+
+export HFILES := $(addsuffix .h,$(subst .,_,$(BINFILES)))
 
 #---------------------------------------------------------------------------------
 # build a list of include paths
@@ -124,6 +127,8 @@ DEPENDS	:=	$(OFILES:.o=.d)
 #---------------------------------------------------------------------------------
 $(OUTPUT).dol: $(OUTPUT).elf
 $(OUTPUT).elf: $(OFILES)
+
+$(OFILES_SOURCES) : $(HFILES)
 
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the various extension

--- a/Makefile.wii
+++ b/Makefile.wii
@@ -128,21 +128,22 @@ $(OUTPUT).elf: $(OFILES)
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the various extension
 #---------------------------------------------------------------------------------
-%.jpg.o	:	%.jpg
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.jpg.o	%_jpg.h :	%.jpg
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
-%.png.o	:	%.png
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
 
-%.pcm.o	:	%.pcm
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.png.o	%_png.h :	%.png
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
-%.ogg.o	:	%.ogg
-	@echo $(notdir $<)
-	bin2s -a 32 $< | $(AS) -o $(@)
+%.pcm.o	%_pcm.h :	%.pcm
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
+
+%.ogg.o	%_ogg.h :	%.ogg
+	$(SILENTMSG) $(notdir $<)
+	$(SILENTCMD)$(bin2o)
 
 -include $(DEPENDS)
 

--- a/gx/gui/cheats.c
+++ b/gx/gui/cheats.c
@@ -50,13 +50,13 @@
 #define MAX_DESC_LENGTH (63)
 
 #ifdef HW_RVL
-extern const u8 Key_Minus_wii_png[];
-extern const u8 Key_Plus_wii_png[];
+#include "Key_Minus_wii_png.h"
+#include "Key_Plus_wii_png.h"
 #else
-extern const u8 Key_R_gcn_png[];
-extern const u8 Key_L_gcn_png[];
+#include "Key_R_gcn_png.h"
+#include "Key_L_gcn_png.h"
 #endif
-extern const u8 Key_DPAD_png[];
+#include "Key_DPAD_png.h"
 
 typedef struct 
 {

--- a/gx/gui/filesel.c
+++ b/gx/gui/filesel.c
@@ -49,12 +49,12 @@
 
 #define SCROLL_SPEED 10
 
-extern const u8 Browser_dir_png[];
-extern const u8 Snap_empty_png[];
-extern const u8 Cart_md_png[];
-extern const u8 Cart_ms_png[];
-extern const u8 Cart_gg_png[];
-extern const u8 Cart_sg_png[];
+#include "Browser_dir_png.h"
+#include "Snap_empty_png.h"
+#include "Cart_md_png.h"
+#include "Cart_ms_png.h"
+#include "Cart_gg_png.h"
+#include "Cart_sg_png.h"
 
 FILEENTRIES filelist[MAXFILES];
 

--- a/gx/gui/gui.h
+++ b/gx/gui/gui.h
@@ -168,61 +168,60 @@ extern gx_texture *w_pointer;
 #endif
 
 /* Generic backgrounds */
-extern const u8 Bg_layer_png[];
-extern const u8 Bg_overlay_png[];
-extern const u8 Banner_main_png[];
-extern const u8 Banner_bottom_png[];
-extern const u8 Banner_top_png[];
-extern const u8 Main_logo_png[];
+#include "Bg_layer_png.h"
+#include "Bg_overlay_png.h"
+#include "Banner_main_png.h"
+#include "Banner_bottom_png.h"
+#include "Banner_top_png.h"
+#include "Main_logo_png.h"
 
 /* Generic frames */
-extern const u8 Frame_s1_png[];
-extern const u8 Frame_s2_png[];
-extern const u8 Frame_s3_png[];
-extern const u8 Frame_s1_title_png[];
-extern const u8 Frame_s2_title_png[];
-extern const u8 Frame_throbber_png[];
+#include "Frame_s1_png.h"
+#include "Frame_s2_png.h"
+#include "Frame_s3_png.h"
+#include "Frame_s1_title_png.h"
+#include "Frame_s2_title_png.h"
+#include "Frame_throbber_png.h"
 
 /* Generic Buttons */
-extern const u8 Button_text_png[];
-extern const u8 Button_text_over_png[];
-extern const u8 Button_icon_png[];
-extern const u8 Button_icon_over_png[];
-extern const u8 Button_icon_sm_png[];
-extern const u8 Button_icon_sm_over_png[];
-extern const u8 Button_up_png[];
-extern const u8 Button_up_over_png[];
-extern const u8 Button_down_png[];
-extern const u8 Button_down_over_png[];
-extern const u8 Button_arrow_png[];
-extern const u8 Button_arrow_over_png[];
-extern const u8 Button_digit_png[];
-extern const u8 Button_digit_over_png[];
+#include "Button_text_png.h"
+#include "Button_text_over_png.h"
+#include "Button_icon_png.h"
+#include "Button_icon_over_png.h"
+#include "Button_icon_sm_png.h"
+#include "Button_icon_sm_over_png.h"
+#include "Button_up_png.h"
+#include "Button_up_over_png.h"
+#include "Button_down_png.h"
+#include "Button_down_over_png.h"
+#include "Button_arrow_png.h"
+#include "Button_arrow_over_png.h"
+#include "Button_digit_png.h"
+#include "Button_digit_over_png.h"
 
 /* Generic images*/
 #ifdef HW_RVL
 #define Key_A_png Key_A_wii_png
 #define Key_B_png Key_B_wii_png
-extern const u8 generic_point_png[];
-extern const u8 Key_A_wii_png[];
-extern const u8 Key_B_wii_png[];
+#include "generic_point_png.h"
+#include "Key_A_wii_png.h"
+#include "Key_B_wii_png.h"
 #else
 #define Key_A_png Key_A_gcn_png
 #define Key_B_png Key_B_gcn_png
-extern const u8 Key_A_gcn_png[];
-extern const u8 Key_B_gcn_png[];
+#include "Key_A_gcn_png.h"
+#include "Key_B_gcn_png.h"
 #endif
-extern const u8 Star_full_png[];
-extern const u8 Star_empty_png[];
-extern const u8 Overlay_bar_png[];
+#include "Star_full_png.h"
+#include "Star_empty_png.h"
+#include "Overlay_bar_png.h"
 
 /* Generic Sounds */
-extern const u8 button_over_pcm[];
-extern const u8 button_select_pcm[];
-extern const u8 intro_pcm[];
-extern const u32 button_select_pcm_size;
-extern const u32 button_over_pcm_size;
-extern const u32 intro_pcm_size;
+
+#include "button_over_pcm.h"
+#include "button_select_pcm.h"
+#include "intro_pcm.h"
+
 
 extern u8 SILENT;
 

--- a/gx/gui/legal.c
+++ b/gx/gui/legal.c
@@ -41,10 +41,10 @@
 #include "font.h"
 #include "gui.h"
 
-extern const u8 Bg_intro_c1_png[];
-extern const u8 Bg_intro_c2_png[];
-extern const u8 Bg_intro_c3_png[];
-extern const u8 Bg_intro_c4_png[];
+#include "Bg_intro_c1_png.h"
+#include "Bg_intro_c2_png.h"
+#include "Bg_intro_c3_png.h"
+#include "Bg_intro_c4_png.h"
 
 /* 
  * This is the legal stuff - which must be shown at program startup 

--- a/gx/gui/menu.c
+++ b/gx/gui/menu.c
@@ -54,82 +54,82 @@
 #include <ogc/lwp_watchdog.h>
 
 /* Credits */
-extern const u8 Bg_credits_png[];
+#include "Bg_credits_png.h"
 
 /* Main menu */
-extern const u8 Main_load_png[];
-extern const u8 Main_options_png[];
-extern const u8 Main_quit_png[];
-extern const u8 Main_file_png[];
-extern const u8 Main_reset_png[];
-extern const u8 Main_cheats_png[];
-extern const u8 Main_showinfo_png[];
-extern const u8 Main_takeshot_png[];
+#include "Main_load_png.h"
+#include "Main_options_png.h"
+#include "Main_quit_png.h"
+#include "Main_file_png.h"
+#include "Main_reset_png.h"
+#include "Main_cheats_png.h"
+#include "Main_showinfo_png.h"
+#include "Main_takeshot_png.h"
 #ifdef HW_RVL
-extern const u8 Main_play_wii_png[];
+#include "Main_play_wii_png.h"
 #else
-extern const u8 Main_play_gcn_png[];
+#include "Main_play_gcn_png.h"
 #endif
 
 /* Options menu */
-extern const u8 Option_menu_png[];
-extern const u8 Option_ctrl_png[];
-extern const u8 Option_sound_png[];
-extern const u8 Option_video_png[];
-extern const u8 Option_system_png[];
+#include "Option_menu_png.h"
+#include "Option_ctrl_png.h"
+#include "Option_sound_png.h"
+#include "Option_video_png.h"
+#include "Option_system_png.h"
 
 /* Load ROM menu */
-extern const u8 Load_recent_png[];
-extern const u8 Load_md_png[];
-extern const u8 Load_ms_png[];
-extern const u8 Load_gg_png[];
-extern const u8 Load_sg_png[];
-extern const u8 Load_cd_png[];
+#include "Load_recent_png.h"
+#include "Load_md_png.h"
+#include "Load_ms_png.h"
+#include "Load_gg_png.h"
+#include "Load_sg_png.h"
+#include "Load_cd_png.h"
 
 /* Save Manager menu */
-extern const u8 Button_load_png[];
-extern const u8 Button_load_over_png[];
-extern const u8 Button_save_png[];
-extern const u8 Button_save_over_png[];
-extern const u8 Button_special_png[];
-extern const u8 Button_special_over_png[];
-extern const u8 Button_delete_png[];
-extern const u8 Button_delete_over_png[];
+#include "Button_load_png.h"
+#include "Button_load_over_png.h"
+#include "Button_save_png.h"
+#include "Button_save_over_png.h"
+#include "Button_special_png.h"
+#include "Button_special_over_png.h"
+#include "Button_delete_png.h"
+#include "Button_delete_over_png.h"
 
 /* Controller Settings */
-extern const u8 Ctrl_4wayplay_png[];
-extern const u8 Ctrl_gamepad_png[];
-extern const u8 Ctrl_justifiers_png[];
-extern const u8 Ctrl_menacer_png[];
-extern const u8 Ctrl_mouse_png[];
-extern const u8 Ctrl_xe_1ap_png[];
-extern const u8 Ctrl_activator_png[];
-extern const u8 Ctrl_lightphaser_png[];
-extern const u8 Ctrl_paddle_png[];
-extern const u8 Ctrl_sportspad_png[];
-extern const u8 Ctrl_none_png[];
-extern const u8 Ctrl_teamplayer_png[];
-extern const u8 Ctrl_mastertap_png[];
-extern const u8 Ctrl_graphic_board_png[];
-extern const u8 Ctrl_pad_auto_png[];
-extern const u8 Ctrl_pad2b_png[];
-extern const u8 Ctrl_pad3b_png[];
-extern const u8 Ctrl_pad6b_png[];
-extern const u8 Ctrl_config_png[];
-extern const u8 ctrl_option_off_png[];
-extern const u8 ctrl_option_on_png[];
-extern const u8 ctrl_gamecube_png[];
+#include "Ctrl_4wayplay_png.h"
+#include "Ctrl_gamepad_png.h"
+#include "Ctrl_justifiers_png.h"
+#include "Ctrl_menacer_png.h"
+#include "Ctrl_mouse_png.h"
+#include "Ctrl_xe_1ap_png.h"
+#include "Ctrl_activator_png.h"
+#include "Ctrl_lightphaser_png.h"
+#include "Ctrl_paddle_png.h"
+#include "Ctrl_sportspad_png.h"
+#include "Ctrl_none_png.h"
+#include "Ctrl_teamplayer_png.h"
+#include "Ctrl_mastertap_png.h"
+#include "Ctrl_graphic_board_png.h"
+#include "Ctrl_pad_auto_png.h"
+#include "Ctrl_pad2b_png.h"
+#include "Ctrl_pad3b_png.h"
+#include "Ctrl_pad6b_png.h"
+#include "Ctrl_config_png.h"
+#include "ctrl_option_off_png.h"
+#include "ctrl_option_on_png.h"
+#include "ctrl_gamecube_png.h"
 #ifdef HW_RVL
-extern const u8 ctrl_classic_png[];
-extern const u8 ctrl_nunchuk_png[];
-extern const u8 ctrl_wiimote_png[];
-extern const u8 ctrl_wiiu_png[];
+#include "ctrl_classic_png.h"
+#include "ctrl_nunchuk_png.h"
+#include "ctrl_wiimote_png.h"
+#include "ctrl_wiiu_png.h"
 #endif
 
 /* Generic images */
-extern const u8 Button_sm_blue_png[];
-extern const u8 Button_sm_grey_png[];
-extern const u8 Button_sm_yellow_png[];
+#include "Button_sm_blue_png.h"
+#include "Button_sm_grey_png.h"
+#include "Button_sm_yellow_png.h"
 
 /* Exit callback */
 void (*reload)(void);

--- a/gx/gx_video.c
+++ b/gx/gx_video.c
@@ -53,12 +53,12 @@ typedef struct
   u32 offset;
 } png_image_desc;
 
-extern const u8 Crosshair_p1_png[];
-extern const u8 Crosshair_p2_png[];
-extern const u8 CD_access_off_png[];
-extern const u8 CD_access_on_png[];
-extern const u8 CD_ready_off_png[];
-extern const u8 CD_ready_on_png[];
+#include "Crosshair_p1_png.h"
+#include "Crosshair_p2_png.h"
+#include "CD_access_off_png.h"
+#include "CD_access_on_png.h"
+#include "CD_ready_off_png.h"
+#include "CD_ready_on_png.h"
 
 /*** VI Mode ***/
 GXRModeObj *vmode;


### PR DESCRIPTION
Use the bin2o generated headers instead of replacing it with a direct command line. This avoids the risk of breakage if updated tooling replaces bin2s as well as ensuring source files which reference the data are recompiled when the data changes.

I've also updated the Makefile with the latest changes that allow verbosity to be controlled with `make V=1` and mitigate for issues on some systems with parallel building. 