### PR TITLE
Added .bms extension for parity with Libretro fork

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2208,7 +2208,7 @@ void retro_get_system_info(struct retro_system_info *info)
 #define GIT_VERSION ""
 #endif
    info->library_version = "v1.7.4" GIT_VERSION;
-   info->valid_extensions = "m3u|mdx|md|smd|gen|bin|cue|iso|chd|sms|gg|sg";
+   info->valid_extensions = "m3u|mdx|md|smd|gen|bin|cue|iso|chd|sms|bms|gg|sg";
    info->block_extract = false;
    info->need_fullpath = true;
 }


### PR DESCRIPTION
.bms is a file extension used by TecToy for their SMS ROMs when putting them into their later consoles like the Mega Drive 4. I would like to note that some of the Mega Drive 4 SMS games use undocumented special behavior that will need to be implemented into the emulator separately (source: https://www.smspower.org/forums/16828-TecToyMegadrive4DumpsIncludingMasterSystemGames).

Note: RetroArch implemented support for the .bms extension a few month ago, including in the info file. ~Red