### PR TITLE
Add preliminary support for Demons of Asteborg

### DIFF
--- a/core/cart_hw/md_cart.c
+++ b/core/cart_hw/md_cart.c
@@ -591,6 +591,14 @@ void md_cart_init(void)
     /* cartridge ROM mapping is reinitialized on /VRES */
     cart.hw.bankshift = 1;
   }
+  else if (strstr(rominfo.domestic,"DEMONS OF ASTEBORG"))
+  {
+    /* Demons of Asteborg uses the SSF2 mapper */
+    cart.hw.time_w = mapper_ssf2_w;
+
+    /* cartridge ROM mapping is reinitialized on /VRES */
+    cart.hw.bankshift = 1;
+  }
   else if (strstr(rominfo.domestic,"SUPER STREET FIGHTER2"))
   {
     /* SSF2 mapper */

--- a/core/loadrom.h
+++ b/core/loadrom.h
@@ -41,7 +41,7 @@
 #define _LOADROM_H_
 
 #ifndef MAXROMSIZE
-#define MAXROMSIZE 10485760
+#define MAXROMSIZE 33554432
 #endif
 
 typedef struct


### PR DESCRIPTION
Hi.

These changes add preliminary support for Demons of Asteborg, a new game that was just released. More info here: https://www.demonsofasteborg.com/

Specifically:

- Increase MAXROMSIZE to 32MB, which was already set in the makefile for some projects (SDL1 and VS makefile). Game would crash with a "File is too large." message before.
- Add header detection to use SSF2 mapper, per the developer's guidance (@Infitek).

What is missing now is SRAM support, which I don't believe is working for SSF2 either. Would appreciate guidance if I am to try to implement it myself, though the game seems to load for now with these changes. I submitted this to the libretro fork as well, but the SRAM changes will probably be beyond my capabilities here.

Thanks and keep up the great work.