### PR TITLE
move sram to separate area

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -55,6 +55,7 @@ ifneq (,$(findstring unix,$(platform)))
    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
    PLATFORM_DEFINES := -DHAVE_ZLIB
+   CFLAGS += '-DMAXROMSIZE=(16<<20)'
 
    # RockPro64
    ifneq (,$(findstring rockpro64,$(platform)))
@@ -513,10 +514,11 @@ CFLAGS += -D_CRT_SECURE_NO_DEPRECATE
 # Windows
 else
    TARGET := $(TARGET_NAME)_libretro.dll
-   CC = gcc
+   CC ?= gcc
    SHARED := -shared -static-libgcc -static-libstdc++ -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
    ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
    PLATFORM_DEFINES := -DHAVE_ZLIB
+   CFLAGS += '-DMAXROMSIZE=(16<<20)'
 
 endif
 

--- a/core/cart_hw/md_cart.h
+++ b/core/cart_hw/md_cart.h
@@ -82,6 +82,7 @@ typedef struct
   uint8 special;          /* custom external hardware (Lock-On, J-Cart, 3-D glasses, Terebi Oekaki,...) */
   cart_hw_t hw;           /* cartridge internal hardware */
   uint8 rom[MAXROMSIZE];  /* ROM area */
+  uint8 sram[0x10000];    /* SRAM area */
 } md_cart_t;
 
 

--- a/core/cart_hw/sram.c
+++ b/core/cart_hw/sram.c
@@ -63,9 +63,7 @@ void sram_init()
 {
   memset(&sram, 0, sizeof (T_SRAM));
 
-  /* backup RAM data is stored above cartridge ROM area, at $800000-$80FFFF (max. 64K) */
-  if (cart.romsize > 0x800000) return;
-  sram.sram = cart.rom + 0x800000;
+  sram.sram = cart.sram;
 
   /* initialize Backup RAM */
   if (strstr(rominfo.international,"Sonic 1 Remastered"))


### PR DESCRIPTION
0x800000 is still used at places as 'max' size, however shouldn't conflict with asteborg