### PR TITLE
[Core/CD] Fix various MCD registers, based on the hardware manual and mcd-verificator (#408)

### DIFF
--- a/core/cd_hw/cdc.c
+++ b/core/cd_hw/cdc.c
@@ -648,11 +648,16 @@ unsigned char cdc_reg_r(void)
 
         return data;
       }
+      
+      default:
+      {
+        /* by default, COMIN is always empty */
+        return 0xff;
+      }
     }
   }
-
-  /* by default, COMIN is always empty */
-  return 0xff;
+  
+  return 0x00;
 }
 
 unsigned short cdc_host_r(void)

--- a/core/mem68k.c
+++ b/core/mem68k.c
@@ -349,7 +349,13 @@ unsigned int ctrl_io_read_byte(unsigned int address)
         if (index == 0x03)
         {
           m68k_poll_detect(1<<0x03);
-          return scd.regs[0x03>>1].byte.l;
+          return scd.regs[0x03>>1].byte.l & 0xc7;
+        }
+
+        /* CDC mode */
+        if (index == 0x04)
+        {
+          return scd.regs[0x04>>1].byte.h & 0xc7;
         }
 
         /* SUB-CPU communication flags */
@@ -503,7 +509,13 @@ unsigned int ctrl_io_read_word(unsigned int address)
         if (index == 0x02)
         {
           m68k_poll_detect(1<<0x03);
-          return scd.regs[0x03>>1].w;
+          return scd.regs[0x03>>1].w & 0xffc7;
+        }
+
+        /* CDC mode */
+        if (index == 0x04)
+        {
+          return scd.regs[0x04>>1].w & 0xc700;
         }
 
         /* CDC host data (word access only ?) */


### PR DESCRIPTION
Fixes a number of errors reported by mcd-verificator (#408). Half is just simple bit masks to prevent unused bits from being written/read.

The other has to do with how the CDC register select and read/write actually functions. According to mcd-verificator, bit 4 in the CDC register select register is the "RS" flag, which you can read up on Sanyo LC8950/LC8951 manual. Interestingly, it seems that when the CDC register ID wraps back to 0 from 0xF, it'll actually switch the RS flag, effectively making it act as sort of a 5th bit? From the tests done in mcd-verificator, it seems to just act as an access enable flag of sorts? The LC8950 manual says that the RS flag is for dictating how registers are accessed (low ="direct addressing"/"AR", high = "indirect addressing"/"the register pointed to by AR", which I guess is for setups where you would switch between setting the register ID and register data within the same address, which isn't applicable to the MCD, since the 2 are split). The current implementation is based on what mcd-verificator has perceived it. Also, even if the register select is set to 0, it'll still increment on a register read/write if the RS flag is set. It'll only not increment if it's clear.

Minus the timing test errors, register X002 and the CDC register select/register data registers are reported as working correctly in mcd-verificator.