### PR TITLE
Fix -Werror=strict-prototypes

### DIFF
--- a/core/cart_hw/eeprom_93c.c
+++ b/core/cart_hw/eeprom_93c.c
@@ -47,7 +47,7 @@
 
 T_EEPROM_93C eeprom_93c;
 
-void eeprom_93c_init()
+void eeprom_93c_init(void)
 {
   /* default eeprom state */
   memset(&eeprom_93c, 0, sizeof(T_EEPROM_93C));

--- a/core/cart_hw/eeprom_93c.h
+++ b/core/cart_hw/eeprom_93c.h
@@ -65,7 +65,7 @@ typedef struct
 extern T_EEPROM_93C eeprom_93c;
 
 /* Function prototypes */
-extern void eeprom_93c_init();
+extern void eeprom_93c_init(void);
 extern void eeprom_93c_write(unsigned char data);
 extern unsigned char eeprom_93c_read(void);
 

--- a/core/cart_hw/eeprom_i2c.c
+++ b/core/cart_hw/eeprom_i2c.c
@@ -179,7 +179,7 @@ static struct
 /* I2C EEPROM mapper initialization                                 */
 /********************************************************************/
 
-void eeprom_i2c_init()
+void eeprom_i2c_init(void)
 {
   int i = sizeof(i2c_database) / sizeof(T_I2C_GAME) - 1;
 
@@ -246,7 +246,7 @@ void eeprom_i2c_init()
 /* I2C EEPROM internal                                   			*/
 /********************************************************************/
 
-INLINE void Detect_START()
+INLINE void Detect_START(void)
 {
   /* detect SDA HIGH to LOW transition while SCL is held HIGH */
   if (eeprom_i2c.old_scl && eeprom_i2c.scl)
@@ -273,7 +273,7 @@ INLINE void Detect_START()
   }
 }
 
-INLINE void Detect_STOP()
+INLINE void Detect_STOP(void)
 {
   /* detect SDA LOW to HIGH transition while SCL is held HIGH */
   if (eeprom_i2c.old_scl && eeprom_i2c.scl)

--- a/core/cart_hw/eeprom_i2c.h
+++ b/core/cart_hw/eeprom_i2c.h
@@ -40,6 +40,6 @@
 #define _EEPROM_I2C_H_
 
 /* Function prototypes */
-extern void eeprom_i2c_init();
+extern void eeprom_i2c_init(void);
 
 #endif

--- a/core/cart_hw/eeprom_spi.c
+++ b/core/cart_hw/eeprom_spi.c
@@ -72,7 +72,7 @@ typedef struct
 
 static T_EEPROM_SPI spi_eeprom;
 
-void eeprom_spi_init()
+void eeprom_spi_init(void)
 {
   /* reset eeprom state */
   memset(&spi_eeprom, 0, sizeof(T_EEPROM_SPI));

--- a/core/cart_hw/eeprom_spi.h
+++ b/core/cart_hw/eeprom_spi.h
@@ -40,7 +40,7 @@
 #define _EEPROM_SPI_H_
 
 /* Function prototypes */
-extern void eeprom_spi_init();
+extern void eeprom_spi_init(void);
 extern void eeprom_spi_write(unsigned char data);
 extern unsigned int eeprom_spi_read(unsigned int address);
 

--- a/core/cart_hw/sram.c
+++ b/core/cart_hw/sram.c
@@ -59,7 +59,7 @@ T_SRAM sram;
  *
  * Assuming max. 64k backup RAM throughout
  ****************************************************************************/
-void sram_init()
+void sram_init(void)
 {
   /* disable Backup RAM by default */
   sram.detected = sram.on = sram.custom = sram.start = sram.end = 0;

--- a/core/cart_hw/sram.h
+++ b/core/cart_hw/sram.h
@@ -51,7 +51,7 @@ typedef struct
 } T_SRAM;
 
 /* Function prototypes */
-extern void sram_init();
+extern void sram_init(void);
 extern unsigned int sram_read_byte(unsigned int address);
 extern unsigned int sram_read_word(unsigned int address);
 extern void sram_write_byte(unsigned int address, unsigned int data);

--- a/core/input_hw/mouse.c
+++ b/core/input_hw/mouse.c
@@ -56,7 +56,7 @@ void mouse_reset(int port)
   mouse.Port = port;
 }
 
-unsigned char mouse_read()
+unsigned char mouse_read(void)
 {
   unsigned int temp = 0x00;
   int x = input.analog[mouse.Port][0];

--- a/core/m68k/s68kcpu.c
+++ b/core/m68k/s68kcpu.c
@@ -348,7 +348,7 @@ void s68k_pulse_halt(void)
   CPU_STOPPED |= STOP_LEVEL_HALT;
 }
 
-void s68k_clear_halt()
+void s68k_clear_halt(void)
 {
   /* Clear the HALT line on the CPU */
   CPU_STOPPED &= ~STOP_LEVEL_HALT;

--- a/core/sound/psg.c
+++ b/core/sound/psg.c
@@ -112,7 +112,7 @@ void psg_init(PSG_TYPE type)
   psg.noiseBitMask = noiseBitMask[type];
 }
 
-void psg_reset()
+void psg_reset(void)
 {
   int i;
 

--- a/core/sound/ym2612.c
+++ b/core/sound/ym2612.c
@@ -779,7 +779,7 @@ INLINE void CSMKeyControll(FM_CH *CH)
   ym2612.OPN.SL3.key_csm = 1;
 }
 
-INLINE void INTERNAL_TIMER_A()
+INLINE void INTERNAL_TIMER_A(void)
 {
   if (ym2612.OPN.ST.mode & 0x01)
   {
@@ -1034,7 +1034,7 @@ INLINE void set_sl_rr(FM_SLOT *SLOT,int v)
 }
 
 /* advance LFO to next sample */
-INLINE void advance_lfo()
+INLINE void advance_lfo(void)
 {
   if (ym2612.OPN.lfo_timer_overflow)   /* LFO enabled ? */
   {

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -2385,7 +2385,7 @@ void ROMCheatUpdate(void)
   }
 }
 
-static void set_memory_maps()
+static void set_memory_maps(void)
 {
    if (system_hw == SYSTEM_MCD)
    {


### PR DESCRIPTION
This will be required for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240