### PR TITLE
Fix -Wmaybe-uninitialized warnings

### DIFF
--- a/core/input_hw/xe_1ap.c
+++ b/core/input_hw/xe_1ap.c
@@ -78,9 +78,6 @@ INLINE unsigned char xe_1ap_read(int index)
     case 3: /* CH1 high (Analog Stick Up/Down direction) */
       data = (input.analog[port][1] >> 4) & 0x0F;
       break;
-    case 4: /* CH2 high (N/A) */
-      data = 0x0;
-      break;
     case 5: /* CH3 high (Throttle vertical or horizontal direction) */
       data = (input.analog[port+1][0] >> 4) & 0x0F;
       break;
@@ -90,9 +87,6 @@ INLINE unsigned char xe_1ap_read(int index)
     case 7: /* CH1 low (Analog Stick Up/Down direction)*/
       data = input.analog[port][1] & 0x0F;
       break;
-    case 8: /* CH2 low (N/A) */
-      data = 0x0;
-      break;
     case 9: /* CH3 low (Throttle vertical or horizontal direction) */
       data = input.analog[port+1][0] & 0x0F;
       break;
@@ -101,6 +95,9 @@ INLINE unsigned char xe_1ap_read(int index)
       break;
     case 11: /* A B A' B' buttons status (active low) */
       data = (~input.pad[port] >> 6) & 0x0F;
+      break;
+    default: /* case 4: case 8: CH2 high/low (N/A) */
+      data = 0x0;
       break;
   }
 

--- a/core/vdp_render.c
+++ b/core/vdp_render.c
@@ -1852,7 +1852,7 @@ void render_bg_m5_vs(int line)
 /* Enhanced function that allows each cell to be vscrolled individually, instead of being limited to 2-cell */
 void render_bg_m5_vs_enhanced(int line)
 {
-  int column, v_offset;
+  int column, v_offset = 0;
   uint32 atex, atbuf, *src, *dst;
   uint32 v_line, next_v_line, *nt;
 


### PR DESCRIPTION
This silences some verbose `-Wmaybe-uninitialized` warnings with `gcc 12.2.1`.

@ekeeke please review for correctness.

```
    In function 'xe_1ap_read',
        inlined from 'xe_1ap_1_read' at core/input_hw/xe_1ap.c:158:10:
    core/input_hw/xe_1ap.c:108:8: warning: 'data' may be used uninitialized [-Wmaybe-uninitialized]
      108 |   data |= ((xe_1ap[index].Counter & 1) << 4);
          |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    core/input_hw/xe_1ap.c: In function 'xe_1ap_1_read':
    core/input_hw/xe_1ap.c:63:17: note: 'data' was declared here
       63 |   unsigned char data;
          |                 ^~~~
    In function 'xe_1ap_read',
        inlined from 'xe_1ap_2_read' at core/input_hw/xe_1ap.c:163:10:
    core/input_hw/xe_1ap.c:108:8: warning: 'data' may be used uninitialized [-Wmaybe-uninitialized]
      108 |   data |= ((xe_1ap[index].Counter & 1) << 4);
          |   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    core/input_hw/xe_1ap.c: In function 'xe_1ap_2_read':
    core/input_hw/xe_1ap.c:63:17: note: 'data' was declared here
       63 |   unsigned char data;
          |                 ^~~~
```
```
    core/vdp_render.c: In function 'render_bg_m5_vs_enhanced':
    core/vdp_render.c:2085:22: warning: 'v_offset' may be used uninitialized [-Wmaybe-uninitialized]
     2085 |       v_line = (line + v_offset + vs[column]) & pf_row_mask;
          |                 ~~~~~^~~~~~~~~~
    core/vdp_render.c:1855:15: note: 'v_offset' was declared here
     1855 |   int column, v_offset;
          |               ^~~~~~~~
```