### PR TITLE
fix error in zstate comment

### DIFF
--- a/core/genesis.c
+++ b/core/genesis.c
@@ -50,7 +50,7 @@ uint8 boot_rom[0x800];    /* Genesis BOOT ROM   */
 uint8 work_ram[0x10000];  /* 68K RAM  */
 uint8 zram[0x2000];       /* Z80 RAM  */
 uint32 zbank;             /* Z80 bank window address */
-uint8 zstate;             /* Z80 bus state (d0 = BUSACK, d1 = /RESET) */
+uint8 zstate;             /* Z80 bus state (d0 = /RESET, d1 = BUSACK) */
 uint8 pico_current;       /* PICO current page */
 
 static uint8 tmss[4];     /* TMSS security register */


### PR DESCRIPTION
This PR fixes the zstate variable comment error discussed in #508