### PR TITLE
Fix nonstandard default for CD add-on (MD mode)

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -187,7 +187,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "none",         "None" },
          { NULL, NULL },
       },
-      "disabled"
+      "auto"
    },
    {
       "genesis_plus_gx_lock_on",


### PR DESCRIPTION
Fixes https://github.com/libretro/Genesis-Plus-GX/issues/341