### PR TITLE
Minimal set of changes required to make savestates determistic

### DIFF
--- a/core/cart_hw/areplay.h
+++ b/core/cart_hw/areplay.h
@@ -39,6 +39,21 @@
 #ifndef _AREPLAY_H_
 #define _AREPLAY_H_
 
+#include "../types.h"
+
+struct action_replay_t
+{
+  uint8 enabled;
+  uint8 status;
+  uint8 ram[0x10000];
+  uint16 regs[13];
+  uint16 old[4];
+  uint16 data[4];
+  uint32 addr[4];
+};
+
+extern struct action_replay_t action_replay;
+
 #define AR_SWITCH_OFF     (0)
 #define AR_SWITCH_ON      (1)
 #define AR_SWITCH_TRAINER (2)

--- a/core/cart_hw/ggenie.c
+++ b/core/cart_hw/ggenie.c
@@ -108,6 +108,7 @@ void ggenie_reset(int hard)
     }
 
     /* Game Genie ROM is mapped at $000000-$007fff */
+    m68k.memory_map[0].target = MM_TARGET_CART_LOCK_ROM;
     m68k.memory_map[0].base = cart.lockrom;
 
     /* Internal registers are mapped at $000000-$00001f */
@@ -202,6 +203,7 @@ static void ggenie_write_regs(unsigned int offset, unsigned int data)
     if (data & 0x400)
     {
       /* $0000-$7ffff reads mapped to Cartridge ROM */
+      m68k.memory_map[0].target = MM_TARGET_CART_ROM;
       m68k.memory_map[0].base = cart.rom;
       m68k.memory_map[0].read8 = NULL; 
       m68k.memory_map[0].read16 = NULL; 
@@ -209,6 +211,7 @@ static void ggenie_write_regs(unsigned int offset, unsigned int data)
     else
     {
       /* $0000-$7ffff reads mapped to Game Genie ROM */
+      m68k.memory_map[0].target = MM_TARGET_CART_LOCK_ROM;
       m68k.memory_map[0].base = cart.lockrom;
       m68k.memory_map[0].read8 = NULL; 
       m68k.memory_map[0].read16 = NULL; 

--- a/core/cart_hw/md_cart.c
+++ b/core/cart_hw/md_cart.c
@@ -357,6 +357,7 @@ void md_cart_init(void)
   for (i=0; i<0x40; i++)
   {
     /* cartridge ROM */
+    m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base     = cart.rom + ((i<<16) & cart.mask);
     m68k.memory_map[i].read8    = NULL;
     m68k.memory_map[i].read16   = NULL;
@@ -369,6 +370,7 @@ void md_cart_init(void)
   for (i=0x40; i<0x80; i++)
   {
     /* unused area */
+    m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base     = cart.rom + (i<<16);
     m68k.memory_map[i].read8    = m68k_read_bus_8;
     m68k.memory_map[i].read16   = m68k_read_bus_16;
@@ -385,6 +387,7 @@ void md_cart_init(void)
     for (i=0x00; i<0x10; i++)
     {
       /* $200000-$3fffff: mirror of $000000-$1fffff (VA21 not connected to ROM chip) */
+      m68k.memory_map[i].target = m68k.memory_map[i + 0x20].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = m68k.memory_map[i + 0x20].base = cart.rom + ((i & 0x03) << 16);
     }
 
@@ -392,6 +395,7 @@ void md_cart_init(void)
     for (i=0x10; i<0x20; i++)
     {
       /* $200000-$3fffff: mirror of $000000-$1fffff (VA21 not connected to ROM chip) */
+      m68k.memory_map[i].target = m68k.memory_map[i + 0x20].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = m68k.memory_map[i + 0x20].base = cart.rom + 0x40000 + ((i & 0x03) << 16);
     }
   }
@@ -411,6 +415,7 @@ void md_cart_init(void)
       /* except for Sonic the Hedgehog 3 (cartridge ROM mirrored in upper 2MB area at power on) */
       if (strstr(rominfo.international,"SONIC THE HEDGEHOG 3") == NULL)
       {
+        m68k.memory_map[sram.start >> 16].target  = MM_TARGET_SRAM;
         m68k.memory_map[sram.start >> 16].base    = sram.sram;
         m68k.memory_map[sram.start >> 16].read8   = sram_read_byte;
         m68k.memory_map[sram.start >> 16].read16  = sram_read_word;
@@ -429,6 +434,7 @@ void md_cart_init(void)
       /* NB: existing 4MB ROM dumps include SRAM data at ROM offsets 0x200000-0x2fffff */ 
       for (i=0x20; i<0x30; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_SRAM;
         m68k.memory_map[i].base    = sram.sram;
         m68k.memory_map[i].read8   = sram_read_byte;
         m68k.memory_map[i].read16  = sram_read_word;
@@ -444,6 +450,7 @@ void md_cart_init(void)
       {
         for (i=0x30; i<0x40; i++)
         {
+          m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + ((i - 0x10) << 16);
         }
       }
@@ -580,6 +587,7 @@ void md_cart_init(void)
     /* cartridge ROM is mapped to $3C0000-$3FFFFF on reset */
     for (i=0x3c; i<0x40; i++)
     {
+      m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base     = cart.rom + (i << 16);
       m68k.memory_map[i].read8    = NULL;
       m68k.memory_map[i].read16   = NULL;
@@ -613,12 +621,14 @@ void md_cart_init(void)
     /* first 256K ROM bank is mirrored into $000000-$1FFFFF on reset */
     for (i=0x00; i<0x20; i++)
     {
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + ((i & 0x03) << 16);
     }
 
     /* 32K static RAM mapped to $200000-$2FFFFF is disabled on reset */
     for (i=0x20; i<0x30; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_SRAM;
       m68k.memory_map[i].base    = sram.sram;
       m68k.memory_map[i].read8   = m68k_read_bus_8;
       m68k.memory_map[i].read16  = m68k_read_bus_16;
@@ -666,6 +676,7 @@ void md_cart_init(void)
     for (i=0x08; i<0x10; i++)
     {
       /* lower 512KB mirrored */
+      m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + ((i & 7) << 16);
     }
 
@@ -683,6 +694,7 @@ void md_cart_init(void)
     for (i=0x60; i<0x70; i++)
     {
       /* custom hardware */
+      m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base   = cart.rom + 0x0f0000;
       m68k.memory_map[i].read8  = ((i & 0x07) < 0x04) ? NULL : mapper_smw_64_r;
       m68k.memory_map[i].read16  = ((i & 0x07) < 0x04) ? NULL : mapper_smw_64_r;
@@ -702,6 +714,7 @@ void md_cart_init(void)
     /* assume linear ROM mapping by default (max. 10MB) */
     for (i=0x40; i<0xA0; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base   = cart.rom + (i<<16);
       m68k.memory_map[i].read8  = NULL;
       m68k.memory_map[i].read16 = NULL;
@@ -755,6 +768,7 @@ void md_cart_init(void)
             /* $000000-$1FFFFF is mapped to S&K ROM */
             for (i=0x00; i<0x20; i++)
             {
+              m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
               m68k.memory_map[i].base = cart.rom + 0x400000 + (i << 16);
             }
 
@@ -820,6 +834,7 @@ void md_cart_reset(int hard_reset)
     /* Boot ROM (8KB mirrored) is mapped to $000000-$3FFFFF */
     for (i=0x00; i<0x40; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + 0x400000;
     }
 
@@ -834,6 +849,7 @@ void md_cart_reset(int hard_reset)
   {
     for (i=0x00; i<0x40; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + ((i<<16) & cart.mask);
     }
   }
@@ -872,6 +888,7 @@ void md_cart_reset(int hard_reset)
         /* disable UPMEM chip at $300000-$3fffff */
         for (i=0x30; i<0x40; i++)
         {
+          m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + ((i<<16) & cart.mask);
         }
       }
@@ -890,29 +907,6 @@ int md_cart_context_save(uint8 *state)
   int i;
   int bufferptr = 0;
   uint8 *base;
-
-  /* cartridge mapping */
-  for (i=0; i<0x40; i++)
-  {
-    /* get base address */
-    base = m68k.memory_map[i].base;
-
-    if (base == sram.sram)
-    {
-      /* SRAM */
-      state[bufferptr++] = 0xff;
-    }
-    else if (base == boot_rom)
-    {
-      /* Boot ROM */
-      state[bufferptr++] = 0xfe;
-    }
-    else
-    {
-      /* Cartridge ROM */
-      state[bufferptr++] = ((base - cart.rom) >> 16) & 0xff;
-    }
-  }
 
   /* hardware registers */
   save_param(cart.hw.regs, sizeof(cart.hw.regs));
@@ -939,42 +933,6 @@ int md_cart_context_load(uint8 *state)
   int i;
   int bufferptr = 0;
   uint8 offset;
-
-  /* cartridge mapping */
-  for (i=0; i<0x40; i++)
-  {
-    /* get offset */
-    offset = state[bufferptr++];
-
-    if (offset == 0xff)
-    {
-      /* SRAM */
-      m68k.memory_map[i].base     = sram.sram;
-      m68k.memory_map[i].read8    = sram_read_byte;
-      m68k.memory_map[i].read16   = sram_read_word;
-      m68k.memory_map[i].write8   = sram_write_byte;
-      m68k.memory_map[i].write16  = sram_write_word;
-      zbank_memory_map[i].read    = sram_read_byte;
-      zbank_memory_map[i].write   = sram_write_byte;
-
-    }
-    else
-    {
-      /* check if SRAM was mapped there before loading state */
-      if (m68k.memory_map[i].base == sram.sram)
-      {
-        m68k.memory_map[i].read8    = NULL;
-        m68k.memory_map[i].read16   = NULL;
-        m68k.memory_map[i].write8   = m68k_unused_8_w;
-        m68k.memory_map[i].write16  = m68k_unused_16_w;
-        zbank_memory_map[i].read    = NULL;
-        zbank_memory_map[i].write   = zbank_unused_w;
-      }
-
-      /* ROM */
-      m68k.memory_map[i].base = (offset == 0xfe) ? boot_rom : (cart.rom + (offset << 16));
-    }
-  }
 
   /* hardware registers */
   load_param(cart.hw.regs, sizeof(cart.hw.regs));
@@ -1019,6 +977,7 @@ static void mapper_sega_w(uint32 data)
         cart.hw.regs[0] = ((m68k.memory_map[0x20].base - cart.rom) >> 16) & 0xff;
 
         /* Backup RAM mapped to $200000-$20ffff (normally mirrored up to $3fffff but this breaks Sonic Megamix and no game need it) */
+        m68k.memory_map[0x20].target  = MM_TARGET_SRAM;
         m68k.memory_map[0x20].base    = sram.sram;
         m68k.memory_map[0x20].read8   = sram_read_byte;
         m68k.memory_map[0x20].read16  = sram_read_word;
@@ -1046,6 +1005,7 @@ static void mapper_sega_w(uint32 data)
       /* S2K upmem chip mapped to $300000-$3fffff (256KB mirrored) */
       for (i=0x30; i<0x40; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base = (cart.rom + 0x600000) + ((i & 3) << 16);
       }
     }
@@ -1056,6 +1016,7 @@ static void mapper_sega_w(uint32 data)
     if (m68k.memory_map[0x20].base == sram.sram)
     {
       /* current cartridge ROM bank mapped to $200000-$20ffff */
+      m68k.memory_map[0x20].target  = MM_TARGET_CART_ROM;
       m68k.memory_map[0x20].base    = cart.rom + (cart.hw.regs[0] << 16);
       m68k.memory_map[0x20].read8   = NULL;
       m68k.memory_map[0x20].read16  = NULL;
@@ -1071,6 +1032,7 @@ static void mapper_sega_w(uint32 data)
       /* cartridge ROM mapped to $300000-$3fffff */
       for (i=0x30; i<0x40; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base = cart.rom + ((i<<16) & cart.mask);
       }
     }
@@ -1094,7 +1056,9 @@ static void mapper_512k_w(uint32 address, uint32 data)
   /* remap selected ROM page to selected bank */
   for (i=0; i<8; i++)
   {
-    m68k.memory_map[address++].base = src + (i<<16);
+    m68k.memory_map[address].target  = MM_TARGET_CART_ROM;
+    m68k.memory_map[address].base = src + (i<<16);
+    address++;
   }
 }
 
@@ -1128,6 +1092,7 @@ static void mapper_sf001_w(uint32 address, uint32 data)
         /* $000000-$3FFFFF is not mapped */
         for (i=0x00; i<0x40; i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base     = cart.rom + (i << 16);
           m68k.memory_map[i].read8    = m68k_read_bus_8;
           m68k.memory_map[i].read16   = m68k_read_bus_16;
@@ -1144,6 +1109,7 @@ static void mapper_sf001_w(uint32 address, uint32 data)
         /* 256K ROM bank #15 mapped to $000000-$03FFFF  */
         for (i=0x00; i<0x04; i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base     = cart.rom + ((0x38 + i) << 16);
           m68k.memory_map[i].read8    = NULL;
           m68k.memory_map[i].read16   = NULL;
@@ -1153,6 +1119,7 @@ static void mapper_sf001_w(uint32 address, uint32 data)
         /* 256K ROM banks #2 to #15 mapped to $040000-$3BFFFF (last revision) or $040000-$3FFFFF (older revisions) */
         for (i=0x04; i<(sram.start >> 16); i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base     = cart.rom + (i << 16);
           m68k.memory_map[i].read8    = NULL;
           m68k.memory_map[i].read16   = NULL;
@@ -1162,6 +1129,7 @@ static void mapper_sf001_w(uint32 address, uint32 data)
         /* 32K static RAM mirrored into $3C0000-$3FFFFF (odd bytes only) (last revision only) */
         while (i<0x40)
         {
+          m68k.memory_map[i].target   = MM_TARGET_SRAM;
           m68k.memory_map[i].base     = sram.sram;
           m68k.memory_map[i].read8    = sram_read_byte;
           m68k.memory_map[i].read16   = sram_read_word;
@@ -1177,6 +1145,7 @@ static void mapper_sf001_w(uint32 address, uint32 data)
         /* 256K ROM banks #1 to #16 mapped to $000000-$3FFFFF (default) */
         for (i=0x00; i<0x40; i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base     = cart.rom + (i << 16);
           m68k.memory_map[i].read8    = NULL;
           m68k.memory_map[i].read16   = NULL;
@@ -1218,6 +1187,7 @@ static void mapper_sf002_w(uint32 address, uint32 data)
     /* $000000-$1BFFFF mapped to $200000-$3BFFFF */
     for (i=0x20; i<0x3C; i++)
     {
+      m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + ((i & 0x1F) << 16);
     }
   }
@@ -1226,6 +1196,7 @@ static void mapper_sf002_w(uint32 address, uint32 data)
     /* $200000-$3BFFFF mapped to $200000-$3BFFFF */
     for (i=0x20; i<0x3C; i++)
     {
+      m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = cart.rom + (i << 16);
     }
   }
@@ -1295,6 +1266,7 @@ static void mapper_sf004_w(uint32 address, uint32 data)
         /* 5 x 256K ROM banks mapped to $000000-$13FFFF, starting from first page ROM bank */
         for (i=0x00; i<0x14; i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base   = cart.rom + (((base + i) & 0x1f) << 16);
           m68k.memory_map[i].read8  = NULL;
           m68k.memory_map[i].read16 = NULL;
@@ -1314,6 +1286,7 @@ static void mapper_sf004_w(uint32 address, uint32 data)
         /* first page 256K ROM bank mirrored into $000000-$1FFFFF */
         for (i=0x00; i<0x20; i++)
         {
+          m68k.memory_map[i].target   = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = m68k.memory_map[0].base + ((i & 0x03) << 16);
           m68k.memory_map[i].read8  = NULL;
           m68k.memory_map[i].read16 = NULL;
@@ -1343,6 +1316,7 @@ static void mapper_sf004_w(uint32 address, uint32 data)
         /* selected 256K ROM bank mirrored into $000000-$1FFFFF */
         for (i=0x00; i<0x20; i++)
         {
+          m68k.memory_map[i].target = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + ((base + (i & 0x03)) << 16);
         }
       }
@@ -1351,6 +1325,7 @@ static void mapper_sf004_w(uint32 address, uint32 data)
         /* 5 x 256K ROM banks mapped to $000000-$13FFFF, starting from selected bank */
         for (i=0x00; i<0x14; i++)
         {
+          m68k.memory_map[i].target = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + (((base + i) & 0x1f) << 16);
         }
       }
@@ -1398,6 +1373,7 @@ static void mapper_t5740_w(uint32 address, uint32 data)
       base = cart.rom + ((data & 0x0f) << 19);
       for (i=0x28; i<0x30; i++)
       {
+        m68k.memory_map[i].target = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base = base + ((i & 0x07) << 16);
       }
       return;
@@ -1409,6 +1385,7 @@ static void mapper_t5740_w(uint32 address, uint32 data)
       base = cart.rom + ((data & 0x0f) << 19);
       for (i=0x30; i<0x38; i++)
       {
+        m68k.memory_map[i].target = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base = base + ((i & 0x07) << 16);
       }
       return;
@@ -1420,6 +1397,7 @@ static void mapper_t5740_w(uint32 address, uint32 data)
       base = cart.rom + ((data & 0x0f) << 19);
       for (i=0x38; i<0x40; i++)
       {
+        m68k.memory_map[i].target = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base = base + ((i & 0x07) << 16);
       }
       return;
@@ -1524,6 +1502,7 @@ static void mapper_smw_64_w(uint32 address, uint32 data)
           case 0x07:
           {
             /* update selected ROM bank (upper 512K) mapped at $610000-$61ffff */
+            m68k.memory_map[0x61].target = m68k.memory_map[0x69].target = MM_TARGET_CART_ROM;
             m68k.memory_map[0x61].base = m68k.memory_map[0x69].base = cart.rom + 0x080000 + ((data & 0x1c) << 14);
             break;
           }
@@ -1588,6 +1567,7 @@ static void mapper_smw_64_w(uint32 address, uint32 data)
         if (sram.sram[0x02] & 0x80)
         {
           /* update selected ROM bank (upper 512K) mapped at $600000-$60ffff */
+          m68k.memory_map[0x60].target = m68k.memory_map[0x68].target = MM_TARGET_CART_ROM;
           m68k.memory_map[0x60].base = m68k.memory_map[0x68].base = cart.rom + 0x080000 + ((data & 0x1c) << 14);
         }
       }
@@ -1706,6 +1686,7 @@ static void mapper_realtec_w(uint32 address, uint32 data)
             /* adjust 64k mapped area ROM base address according to fixed ROM bank configuration (see above) */
             base = (base & ~cart.hw.regs[1]) | (cart.hw.regs[2] & cart.hw.regs[1]);
 
+            m68k.memory_map[i].target = MM_TARGET_CART_ROM;
             m68k.memory_map[i].base = &cart.rom[base << 16];
           }
 
@@ -1720,11 +1701,13 @@ static void mapper_realtec_w(uint32 address, uint32 data)
 static uint32 mapper_realtec_r(uint32 address)
 {
   /* /VRES is asserted to bypass TMSS licensing screen when first read access to cartridge ROM header is detected */
-  if ((address == 0x100) && (m68k.memory_map[0].base = cart.base))
+  if (address == 0x100)
   {
-    /* asserting /VRES from cartridge should only reset 68k CPU (TODO: confirm this on real hardware) */
-    m68k_pulse_reset();
-  }
+    m68k.memory_map[0].target = cart.target;
+    m68k.memory_map[0].base = cart.base;
+    if (m68k.memory_map[0].base > 0) 
+      m68k_pulse_reset(); /* asserting /VRES from cartridge should only reset 68k CPU (TODO: confirm this on real hardware) */
+  } 
 
   /* default ROM area read handler */
   return *(uint16 *)(m68k.memory_map[0].base + (address & 0xfffe));
@@ -1772,6 +1755,7 @@ static void mapper_32k_w(uint32 data)
     for (i=0; i<0x10; i++)
     {
       /* Remap to unused ROM area  */
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = &cart.rom[0x400000 + (i << 16)];
 
       /* address = address OR (value << 15) */
@@ -1784,6 +1768,7 @@ static void mapper_32k_w(uint32 data)
     /* reset default $000000-$0FFFFF mapping */
     for (i=0; i<16; i++)
     {
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = &cart.rom[i << 16];
     }
   }
@@ -1802,6 +1787,7 @@ static void mapper_64k_w(uint32 data)
     /* bank is mapped at $000000-$0FFFFF */
     for (i=0; i<16; i++)
     {
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = &cart.rom[(data & 0xf) << 16];
     }
   }
@@ -1810,6 +1796,7 @@ static void mapper_64k_w(uint32 data)
     /* reset default $000000-$0FFFFF mapping */
     for (i=0; i<16; i++)
     {
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = &cart.rom[(i & 0xf) << 16];
     }
   }
@@ -1825,6 +1812,7 @@ static void mapper_64k_multi_w(uint32 address)
   /* 64 x 64k banks */
   for (i=0; i<64; i++)
   {
+    m68k.memory_map[i].target = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base = &cart.rom[((address + i) & 0x3f) << 16];
   }
 }
@@ -1855,6 +1843,7 @@ static uint32 mapper_128k_multi_r(uint32 address)
   address = bank << 1;
   for (i=0x00; i<0x40; i++)
   {
+    m68k.memory_map[i].target = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base = &cart.rom[((address + i) & 0x3f) << 16];
   }
 
@@ -1888,6 +1877,7 @@ static void mapper_256k_multi_w(uint32 address, uint32 data)
   address = bank << 2;
   for (i=0x00; i<0x40; i++)
   {
+    m68k.memory_map[i].target = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base = &cart.rom[((address + i) & 0x3f) << 16];
   }
 }
@@ -1907,12 +1897,14 @@ static void mapper_wd1601_w(uint32 address, uint32 data)
     /* upper 2MB ROM mapped to $000000-$1fffff */
     for (i=0; i<0x20; i++)
     {
+      m68k.memory_map[i].target = MM_TARGET_CART_ROM;
       m68k.memory_map[i].base = &cart.rom[(0x20 + i) << 16];
     }
 
     /* backup RAM (8KB) mapped to $2000000-$3fffff */
     for (i=0x20; i<0x40; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_SRAM;
       m68k.memory_map[i].base    = sram.sram;
       m68k.memory_map[i].read8   = sram_read_byte;
       m68k.memory_map[i].read16  = sram_read_word;
@@ -1982,6 +1974,7 @@ static uint32 mapper_64k_radica_r(uint32 address)
   /* $000000-$3fffff area is mapped to selected banks (OR gates between VA21-VA16 and selected index) */
   for (i = 0x00; i < 0x40; i++)
   {
+    m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base = &cart.rom[(index | i) << 16];
   }
 
@@ -2010,12 +2003,14 @@ static uint32 mapper_128k_radica_r(uint32 address)
   /* $000000-$1fffff area is mapped to selected banks (OR gates between VA20-VA17 and selected index) */
   for (i = 0x00; i < 0x20; i++)
   {
+    m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
     m68k.memory_map[i].base = &cart.rom[(index | i) << 16];
   }
 
   /* $200000-$3fffff area is mapped to 8KB SRAM (mirrored) */
   for (i = 0x20; i < 0x40; i++)
   {
+    m68k.memory_map[i].target  = MM_TARGET_SRAM;
     m68k.memory_map[i].base    = sram.sram;
     m68k.memory_map[i].read8   = sram_read_byte;
     m68k.memory_map[i].read16  = sram_read_word;

--- a/core/cart_hw/md_cart.h
+++ b/core/cart_hw/md_cart.h
@@ -44,6 +44,8 @@
 #ifndef _MD_CART_H_
 #define _MD_CART_H_
 
+#include "../m68k/m68k.h"
+
 #ifdef USE_DYNAMIC_ALLOC
 #define cart ext->md_cart
 #else
@@ -83,13 +85,14 @@ typedef struct
 /* Cartridge type */
 typedef struct
 {
-  uint8 *base;            /* ROM base (saved for OS/Cartridge ROM swap) */
-  uint32 romsize;         /* ROM size */
-  uint32 mask;            /* ROM mask */
-  uint8 special;          /* custom external hardware (Lock-On, J-Cart, 3-D glasses, Terebi Oekaki,...) */
-  cart_hw_t hw;           /* cartridge internal hardware */
-  uint8 lockrom[0x10000]; /* Game Genie / (Pro) Action Replay Lock-On ROM area (max 64KB) */
-  uint8 rom[MAXROMSIZE];  /* cartridge ROM area */
+  memory_map_target_t target;    /* ROM base pointer target */
+  uint8 *base;                   /* ROM base (saved for OS/Cartridge ROM swap) */
+  uint32 romsize;                /* ROM size */
+  uint32 mask;                   /* ROM mask */
+  uint8 special;                 /* custom external hardware (Lock-On, J-Cart, 3-D glasses, Terebi Oekaki,...) */
+  cart_hw_t hw;                  /* cartridge internal hardware */
+  uint8 lockrom[0x10000];        /* Game Genie / (Pro) Action Replay Lock-On ROM area (max 64KB) */
+  uint8 rom[MAXROMSIZE];         /* cartridge ROM area */
 } md_cart_t;
 
 /* Function prototypes */

--- a/core/cart_hw/megasd.c
+++ b/core/cart_hw/megasd.c
@@ -157,6 +157,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
         /* map bank #0 selected ROM page to $000000-$07ffff */
         for (i=0x00; i<0x08; i++)
         {
+          m68k.memory_map[i].target = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + (((megasd_hw.bank0 & 0x0f) << 19) & cart.mask) + (i<<16);
         }
       }
@@ -171,6 +172,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
         /* reset default ROM mapping in $000000-$07ffff */
         for (i=0x00; i<0x08; i++)
         {
+          m68k.memory_map[i].target = MM_TARGET_CART_ROM;
           m68k.memory_map[i].base = cart.rom + (i<<16);
         }
       }
@@ -235,6 +237,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
           /* selected ROM page is mapped to selected bank */
           for (i=0; i<8; i++)
           {
+            m68k.memory_map[i].target = MM_TARGET_CART_ROM;
             m68k.memory_map[bank + i].base = src + (i<<16);
           }
         }
@@ -256,6 +259,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
       /* SRAM mapped in $380000-$3fffff (max 16KB) */
       for (i=0x38; i<0x40; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_SRAM;
         m68k.memory_map[i].base    = sram.sram;
         m68k.memory_map[i].read8   = sram_read_byte;
         m68k.memory_map[i].read16  = sram_read_word;
@@ -270,6 +274,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
       /* PCM hardware mapped in $380000-$3fffff */
       for (i=0x38; i<0x40; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_NULL;
         m68k.memory_map[i].base    = NULL;
         m68k.memory_map[i].read8   = megasd_pcm_read_byte;
         m68k.memory_map[i].read16  = megasd_pcm_read_word;
@@ -287,6 +292,7 @@ void megasd_enhanced_ssf2_mapper_w(unsigned int address, unsigned int data)
       /* selected ROM page mapped in $380000-$3fffff */
       for (i=0x38; i<0x40; i++)
       {
+        m68k.memory_map[i].target  = MM_TARGET_CART_ROM;
         m68k.memory_map[i].base    = src + (i << 16);;
         m68k.memory_map[i].read8   = NULL;
         m68k.memory_map[i].read16  = NULL;

--- a/core/cart_hw/svp/svp.c
+++ b/core/cart_hw/svp/svp.c
@@ -53,6 +53,7 @@ void svp_init(void)
   svp = (void *) ((char *)cart.rom + 0x200000);
   memset(svp, 0, sizeof(*svp));
 
+  m68k.memory_map[0x30].target  = MM_TARGET_SVP_DRAM;
   m68k.memory_map[0x30].base    = svp->dram;
   m68k.memory_map[0x30].read8   = NULL;
   m68k.memory_map[0x30].read16  = NULL;
@@ -61,6 +62,7 @@ void svp_init(void)
   zbank_memory_map[0x30].read   = NULL;
   zbank_memory_map[0x30].write  = NULL;
 
+  m68k.memory_map[0x31].target  = MM_TARGET_SVP_DRAM;
   m68k.memory_map[0x31].base    = svp->dram + 0x10000;
   m68k.memory_map[0x31].read8   = NULL;
   m68k.memory_map[0x31].read16  = NULL;

--- a/core/cd_hw/cd_cart.c
+++ b/core/cd_hw/cd_cart.c
@@ -210,6 +210,7 @@ void cd_cart_init(void)
     /* RAM cartridge ID register (read-only) */
     for (i=0x40; i<0x60; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_NULL;
       m68k.memory_map[i].base    = NULL;
       m68k.memory_map[i].read8   = cart_id_read_byte;
       m68k.memory_map[i].read16  = cart_id_read_word;
@@ -222,6 +223,7 @@ void cd_cart_init(void)
     /* RAM cartridge memory */
     for (i=0x60; i<0x70; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_NULL;
       m68k.memory_map[i].base    = NULL;
       m68k.memory_map[i].read8   = cart_ram_read_byte;
       m68k.memory_map[i].read16  = cart_ram_read_word;
@@ -234,6 +236,7 @@ void cd_cart_init(void)
     /* RAM cartridge write protection register */
     for (i=0x70; i<0x80; i++)
     {
+      m68k.memory_map[i].target  = MM_TARGET_NULL;
       m68k.memory_map[i].base    = NULL;
       m68k.memory_map[i].read8   = cart_prot_read_byte;
       m68k.memory_map[i].read16  = cart_prot_read_word;
@@ -253,6 +256,7 @@ void cd_cart_init(void)
     {
       for (i=0; i<0x40; i++)
       {
+        m68k.memory_map[i+0x40].target  = m68k.memory_map[i].target;
         m68k.memory_map[i+0x40].base    = m68k.memory_map[i].base;
         m68k.memory_map[i+0x40].read8   = m68k.memory_map[i].read8;
         m68k.memory_map[i+0x40].read16  = m68k.memory_map[i].read16;

--- a/core/cd_hw/scd.c
+++ b/core/cd_hw/scd.c
@@ -788,6 +788,7 @@ INLINE void word_ram_switch(uint8 mode)
     /* MAIN-CPU: $200000-$21FFFF is mapped to 256K Word-RAM (lower 128K) */
     for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
     {
+      m68k.memory_map[i].base = MM_TARGET_SCD_WORD_RAM_2M;
       m68k.memory_map[i].base = scd.word_ram_2M + ((i & 0x03) << 16);
     }
 
@@ -872,6 +873,7 @@ static void scd_write_byte(unsigned int address, unsigned int data)
             for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
             {
               /* Word-RAM 1 data mapped at $200000-$21FFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
               m68k.memory_map[i].base = scd.word_ram[1] + ((i & 0x01) << 16);
             }
 
@@ -899,6 +901,7 @@ static void scd_write_byte(unsigned int address, unsigned int data)
             for (i=0x0c; i<0x0e; i++)
             {
               /* Word-RAM 0 data mapped at $0C0000-$0DFFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
               s68k.memory_map[i].base = scd.word_ram[0] + ((i & 0x01) << 16);
             }
 
@@ -911,6 +914,7 @@ static void scd_write_byte(unsigned int address, unsigned int data)
             for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
             {
               /* Word-RAM 0 data mapped at $200000-$21FFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
               m68k.memory_map[i].base = scd.word_ram[0] + ((i & 0x01) << 16);
             }
 
@@ -938,6 +942,7 @@ static void scd_write_byte(unsigned int address, unsigned int data)
             for (i=0x0c; i<0x0e; i++)
             {
               /* Word-RAM 1 data mapped at $0C0000-$0DFFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
               s68k.memory_map[i].base = scd.word_ram[1] + ((i & 0x01) << 16);
             }
           }
@@ -1221,6 +1226,7 @@ static void scd_write_word(unsigned int address, unsigned int data)
             for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
             {
               /* Word-RAM 1 data mapped at $200000-$21FFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
               m68k.memory_map[i].base = scd.word_ram[1] + ((i & 0x01) << 16);
             }
 
@@ -1248,6 +1254,7 @@ static void scd_write_word(unsigned int address, unsigned int data)
             for (i=0x0c; i<0x0e; i++)
             {
               /* Word-RAM 0 data mapped at $0C0000-$0DFFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
               s68k.memory_map[i].base = scd.word_ram[0] + ((i & 0x01) << 16);
             }
 
@@ -1260,6 +1267,7 @@ static void scd_write_word(unsigned int address, unsigned int data)
             for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
             {
               /* Word-RAM 0 data mapped at $200000-$21FFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
               m68k.memory_map[i].base = scd.word_ram[0] + ((i & 0x01) << 16);
             }
 
@@ -1287,6 +1295,7 @@ static void scd_write_word(unsigned int address, unsigned int data)
             for (i=0x0c; i<0x0e; i++)
             {
               /* Word-RAM 1 data mapped at $0C0000-$0DFFFF */
+              m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
               s68k.memory_map[i].base = scd.word_ram[1] + ((i & 0x01) << 16);
             }
           }
@@ -1596,6 +1605,7 @@ void scd_init(void)
       case 0x00:
       {
         /* $000000-$01FFFF (resp. $400000-$41FFFF): internal ROM (128KB), mirrored every 256KB up to $1FFFFF (resp. $5FFFFF) */
+        m68k.memory_map[i].target  = MM_TARGET_SCD_BOOT_ROM;
         m68k.memory_map[i].base    = scd.bootrom + ((i & 0x01) << 16);
         m68k.memory_map[i].read8   = NULL;
         m68k.memory_map[i].read16  = NULL;
@@ -1609,6 +1619,7 @@ void scd_init(void)
       case 0x02:
       {
         /* $020000-$03FFFF (resp. $420000-$43FFFF): PRG-RAM (first 128KB bank), mirrored every 256KB up to $1FFFFF (resp. $5FFFFF) */
+        m68k.memory_map[i].target  = MM_TARGET_SCD_PRG_RAM;
         m68k.memory_map[i].base = scd.prg_ram + ((i & 0x01) << 16);
 
         /* automatic mirrored range remapping when switching PRG-RAM banks */
@@ -1639,6 +1650,7 @@ void scd_init(void)
   for (i=base+0x20; i<base+0x40; i++)
   {
     /* $200000-$23FFFF (resp. $600000-$63FFFF): Word-RAM in 2M mode (256KB), mirrored up to $3FFFFF (resp. $7FFFFF) */
+    m68k.memory_map[i].target  = MM_TARGET_SCD_WORD_RAM_2M;
     m68k.memory_map[i].base  = scd.word_ram_2M + ((i & 0x03) << 16);
 
     /* automatic mirrored range remapping when switching Word-RAM */
@@ -1681,6 +1693,7 @@ void scd_init(void)
       case 0x07:
       {
         /* $000000-$07FFFF (mirrored every 1MB): PRG-RAM (512KB) */
+        m68k.memory_map[i].target  = MM_TARGET_SCD_PRG_RAM;
         s68k.memory_map[i].base    = scd.prg_ram + ((i & 0x07) << 16);
         s68k.memory_map[i].read8   = NULL;
         s68k.memory_map[i].read16  = NULL;
@@ -1697,6 +1710,7 @@ void scd_init(void)
       case 0x0b:
       {
         /* $080000-$0BFFFF (mirrored every 1MB): Word-RAM in 2M mode (256KB)*/
+        m68k.memory_map[i].target  = MM_TARGET_SCD_WORD_RAM_2M;
         s68k.memory_map[i].base = scd.word_ram_2M + ((i & 0x03) << 16);
 
         /* automatic mirrored range remapping when switching Word-RAM */
@@ -1722,6 +1736,7 @@ void scd_init(void)
       case 0x0d:
       {
         /* $0C0000-$0DFFFF (mirrored every 1MB):  unused in 2M mode (?) */
+        m68k.memory_map[i].target  = MM_TARGET_SCD_WORD_RAM_2M;
         s68k.memory_map[i].base = scd.word_ram_2M + ((i & 0x03) << 16);
 
         /* automatic mirrored range remapping when switching Word-RAM */
@@ -1745,6 +1760,7 @@ void scd_init(void)
       case 0x0e:
       {
         /* $FE0000-$FEFFFF (mirrored every 1MB): 8KB backup RAM */
+        m68k.memory_map[i].target   = MM_TARGET_NULL;
         s68k.memory_map[i].base     = NULL;
         s68k.memory_map[i].read8    = bram_read_byte;
         s68k.memory_map[i].read16   = bram_read_word;
@@ -1756,6 +1772,7 @@ void scd_init(void)
       case 0x0f:
       {
         /* $FF0000-$FFFFFF (mirrored every 1MB): PCM hardware & SUB-CPU registers  */
+        m68k.memory_map[i].target   = MM_TARGET_NULL;
         s68k.memory_map[i].base     = NULL;
         s68k.memory_map[i].read8    = scd_read_byte;
         s68k.memory_map[i].read16   = scd_read_word;
@@ -1824,6 +1841,8 @@ void scd_reset(int hard)
     }
 
     /* reset PRG-RAM bank on MAIN-CPU side */
+    m68k.memory_map[scd.cartridge.boot + 0x02].target = MM_TARGET_SCD_PRG_RAM;
+    m68k.memory_map[scd.cartridge.boot + 0x03].target = MM_TARGET_SCD_PRG_RAM;
     m68k.memory_map[scd.cartridge.boot + 0x02].base = scd.prg_ram;
     m68k.memory_map[scd.cartridge.boot + 0x03].base = scd.prg_ram + 0x10000;
 
@@ -2123,6 +2142,8 @@ int scd_context_load(uint8 *state, char *version)
   load_param(scd.prg_ram, sizeof(scd.prg_ram));
 
   /* PRG-RAM 128K bank mapped on MAIN-CPU side */
+  m68k.memory_map[scd.cartridge.boot + 0x02].target = MM_TARGET_SCD_PRG_RAM;
+  m68k.memory_map[scd.cartridge.boot + 0x03].target = m68k.memory_map[scd.cartridge.boot + 0x02].target;
   m68k.memory_map[scd.cartridge.boot + 0x02].base = scd.prg_ram + ((scd.regs[0x03>>1].byte.l & 0xc0) << 11);
   m68k.memory_map[scd.cartridge.boot + 0x03].base = m68k.memory_map[scd.cartridge.boot + 0x02].base + 0x10000;
 
@@ -2158,6 +2179,7 @@ int scd_context_load(uint8 *state, char *version)
       for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
       {
         /* Word-RAM 1 data mapped at $200000-$21FFFF */
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
         m68k.memory_map[i].base = scd.word_ram[1] + ((i & 0x01) << 16);
         m68k.memory_map[i].read8   = NULL;
         m68k.memory_map[i].read16  = NULL;
@@ -2191,6 +2213,7 @@ int scd_context_load(uint8 *state, char *version)
       for (i=0x0c; i<0x0e; i++)
       {
         /* Word-RAM 0 data mapped at $0C0000-$0DFFFF */
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
         s68k.memory_map[i].base    = scd.word_ram[0] + ((i & 0x01) << 16);
         s68k.memory_map[i].read8   = NULL;
         s68k.memory_map[i].read16  = NULL;
@@ -2204,6 +2227,7 @@ int scd_context_load(uint8 *state, char *version)
       for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x22; i++)
       {
         /* Word-RAM 0 data mapped at $200000-$21FFFF */
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_0;
         m68k.memory_map[i].base = scd.word_ram[0] + ((i & 0x01) << 16);
         m68k.memory_map[i].read8   = NULL;
         m68k.memory_map[i].read16  = NULL;
@@ -2237,6 +2261,7 @@ int scd_context_load(uint8 *state, char *version)
       for (i=0x0c; i<0x0e; i++)
       {
         /* Word-RAM 1 data mapped at $0C0000-$0DFFFF */
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_1;
         s68k.memory_map[i].base    = scd.word_ram[1] + ((i & 0x01) << 16);
         s68k.memory_map[i].read8   = NULL;
         s68k.memory_map[i].read16  = NULL;
@@ -2256,6 +2281,7 @@ int scd_context_load(uint8 *state, char *version)
       /* MAIN-CPU: $200000-$23FFFF is mapped to 256K Word-RAM */
       for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x24; i++)
       {
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_2M;
         m68k.memory_map[i].base    = scd.word_ram_2M + ((i & 0x03) << 16);
         m68k.memory_map[i].read8   = NULL;
         m68k.memory_map[i].read16  = NULL;
@@ -2279,6 +2305,7 @@ int scd_context_load(uint8 *state, char *version)
       /* MAIN-CPU: $200000-$23FFFF is unmapped */
       for (i=scd.cartridge.boot+0x20; i<scd.cartridge.boot+0x24; i++)
       {
+        m68k.memory_map[i].target = MM_TARGET_SCD_WORD_RAM_2M;
         m68k.memory_map[i].base    = scd.word_ram_2M + ((i & 0x03) << 16);
         m68k.memory_map[i].read8   = m68k_read_bus_8;
         m68k.memory_map[i].read16  = m68k_read_bus_16;

--- a/core/input_hw/gamepad.c
+++ b/core/input_hw/gamepad.c
@@ -40,21 +40,9 @@
 #include "shared.h"
 #include "gamepad.h"
 
-static struct
-{
-  uint8 State;
-  uint8 Counter;
-  uint8 Timeout;
-  uint32 Latency;
-} gamepad[MAX_DEVICES];
-
-static struct
-{
-  uint8 Latch;
-  uint8 Counter;
-} flipflop[2];
-
-static uint8 latch;
+struct gamepad_t gamepad[MAX_DEVICES];
+struct flipflop_t flipflop[2];
+uint8 latch;
 
 
 void gamepad_reset(int port)

--- a/core/input_hw/gamepad.h
+++ b/core/input_hw/gamepad.h
@@ -40,6 +40,26 @@
 #ifndef _GAMEPAD_H_
 #define _GAMEPAD_H_
 
+#include "../types.h"
+
+struct gamepad_t
+{
+  uint8 State;
+  uint8 Counter;
+  uint8 Timeout;
+  uint32 Latency;
+};
+
+struct flipflop_t
+{
+  uint8 Latch;
+  uint8 Counter;
+};
+
+extern struct gamepad_t gamepad[MAX_DEVICES];
+extern struct flipflop_t flipflop[2];
+extern uint8 latch;
+
 /* Function prototypes */
 extern void gamepad_reset(int port);
 extern void gamepad_refresh(int port);

--- a/core/m68k/m68k.h
+++ b/core/m68k/m68k.h
@@ -213,10 +213,30 @@ typedef enum
   M68K_REG_IR    /* Instruction register */
 } m68k_register_t;
 
+/**
+ * Possible targets for memory maps
+*/
+typedef enum
+{
+  MM_TARGET_NULL,
+  MM_TARGET_SCD_WORD_RAM_0,
+  MM_TARGET_SCD_WORD_RAM_1,
+  MM_TARGET_SCD_WORD_RAM_2M,
+  MM_TARGET_SCD_PRG_RAM,
+  MM_TARGET_SCD_BOOT_ROM,
+  MM_TARGET_SRAM,
+  MM_TARGET_BOOT_ROM,
+  MM_TARGET_WORK_RAM,
+  MM_TARGET_CART_ROM,
+  MM_TARGET_CART_LOCK_ROM,
+  MM_TARGET_SVP_DRAM,
+  MM_TARGET_ACTION_REPLAY_RAM
+} memory_map_target_t;
 
 /* 68k memory map structure */
 typedef struct 
 {
+  memory_map_target_t target;                      /* Base pointer target*/
   unsigned char *base;                             /* memory-based access (ROM, RAM) */
   unsigned int (*read8)(unsigned int address);               /* I/O byte read access */
   unsigned int (*read16)(unsigned int address);              /* I/O word read access */

--- a/core/mem68k.c
+++ b/core/mem68k.c
@@ -815,6 +815,8 @@ void ctrl_io_write_byte(unsigned int address, unsigned int data)
             m68k_poll_sync(1<<0x03);
 
             /* PRG-RAM 128k bank mapped to $020000-$03FFFF (resp. $420000-$43FFFF) */
+            m68k.memory_map[scd.cartridge.boot + 0x02].target = MM_TARGET_SCD_PRG_RAM;
+            m68k.memory_map[scd.cartridge.boot + 0x03].target = m68k.memory_map[scd.cartridge.boot + 0x02].target;
             m68k.memory_map[scd.cartridge.boot + 0x02].base = scd.prg_ram + ((data & 0xc0) << 11);
             m68k.memory_map[scd.cartridge.boot + 0x03].base = m68k.memory_map[scd.cartridge.boot + 0x02].base + 0x10000;
 
@@ -1154,6 +1156,8 @@ void ctrl_io_write_word(unsigned int address, unsigned int data)
             m68k_poll_sync(1<<0x03);
 
             /* PRG-RAM 128k bank mapped to $020000-$03FFFF (resp. $420000-$43FFFF) */
+            m68k.memory_map[scd.cartridge.boot + 0x02].target = MM_TARGET_SCD_PRG_RAM;
+            m68k.memory_map[scd.cartridge.boot + 0x03].target = m68k.memory_map[scd.cartridge.boot + 0x02].target;
             m68k.memory_map[scd.cartridge.boot + 0x02].base = scd.prg_ram + ((data & 0xc0) << 11);
             m68k.memory_map[scd.cartridge.boot + 0x03].base = m68k.memory_map[scd.cartridge.boot + 0x02].base + 0x10000;
 

--- a/core/state.h
+++ b/core/state.h
@@ -39,8 +39,8 @@
 #ifndef _STATE_H_
 #define _STATE_H_
 
-#define STATE_SIZE    0xfd000
-#define STATE_VERSION "GENPLUS-GX 1.7.6"
+#define STATE_SIZE    0xfd000 /* TO-DO: Update*/
+#define STATE_VERSION "GENPLUS-GX 1.7.6" /* TO-DO: Update*/
 
 #define load_param(param, size) \
   memcpy(param, &state[bufferptr], size); \

--- a/core/system.c
+++ b/core/system.c
@@ -51,7 +51,7 @@ uint8 system_bios;
 uint32 system_clock;
 int16 SVP_cycles = 800; 
 
-static uint8 pause_b;
+uint8 pause_b;
 static EQSTATE eq[2];
 static int16 llp,rrp;
 

--- a/core/system.h
+++ b/core/system.h
@@ -103,6 +103,7 @@ extern int16 SVP_cycles;
 extern uint8 system_hw;
 extern uint8 system_bios;
 extern uint32 system_clock;
+extern uint8 pause_b;
 
 /* Function prototypes */
 extern int audio_init(int samplerate, double framerate);


### PR DESCRIPTION
Second try, as my previous one #548 was a bit of a brute attempt. It wasn't all wasted work, since I was able to work back from it and identify the very minimal set of modications  to make the save/load state procedures fully deterministic.  In summary:

# Changes made

* Added `pause_b` to the savestate. This seems to be important for my SMS test case (Prince of Persia) not to desync.
* Added `gamepad` to the savestate. It seems that it is important to keep track of the controller states. It might be necessary to add all other input types to the state, when used.
* Created `memory_map_target_t` to generically store the targets pointed to by `base` in the memory maps. This allows calculating base and pointer for all memory maps without the need of black magic. This seemed to have been a problem with desync in two of my test cases (Another World and Virtua Racing). Added an assignment to target every time the base pointer is changed and the appropriate logic in the `load_state` and `save_state` procedures
* Added the rest of the m68k state into the savestate. These are but a few bytes and were the last missing pieces in the puzzle to make my test cases work.

# To-Do:

- [ ] Add at least 20 more games to the test set to make absolutely sure nothing else is needed
- [ ] For `cpu_memory_map`, we might also need to have a generic way to restore the `read8`,  `read16`, `write8` and `write16` functions.
- [ ] Test saving and loading from a file
- [ ] Test other types of inputs to see if their state also need storing (and not only `gamepad`)

Thanks again for your time