### PR TITLE
Adding minimal set of changes to the savestate procedures to ensure full re-record sync

### DIFF
--- a/core/input_hw/gamepad.c
+++ b/core/input_hw/gamepad.c
@@ -40,13 +40,7 @@
 #include "shared.h"
 #include "gamepad.h"
 
-static struct
-{
-  uint8 State;
-  uint8 Counter;
-  uint8 Timeout;
-  uint32 Latency;
-} gamepad[MAX_DEVICES];
+struct gamepad_t gamepad[MAX_DEVICES];
 
 static struct
 {
@@ -55,7 +49,6 @@ static struct
 } flipflop[2];
 
 static uint8 latch;
-
 
 void gamepad_reset(int port)
 {

--- a/core/input_hw/gamepad.h
+++ b/core/input_hw/gamepad.h
@@ -40,6 +40,16 @@
 #ifndef _GAMEPAD_H_
 #define _GAMEPAD_H_
 
+struct gamepad_t
+{
+  uint8 State;
+  uint8 Counter;
+  uint8 Timeout;
+  uint32 Latency;
+};
+
+extern struct gamepad_t gamepad[MAX_DEVICES];
+
 /* Function prototypes */
 extern void gamepad_reset(int port);
 extern void gamepad_refresh(int port);

--- a/core/shared.h
+++ b/core/shared.h
@@ -21,6 +21,7 @@
 #include "membnk.h"
 #include "io_ctrl.h"
 #include "input.h"
+#include "gamepad.h"
 #include "sound.h"
 #include "psg.h"
 #include "ym2413.h"

--- a/core/state.c
+++ b/core/state.c
@@ -71,6 +71,9 @@ int state_load(unsigned char *state)
     zbank_memory_map[i].write   = zbank_write_vdp;
   }
 
+  /* SYSTEM */
+  load_param(&pause_b, sizeof(pause_b));
+
   /* GENESIS */
   if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
   {
@@ -108,6 +111,9 @@ int state_load(unsigned char *state)
   {
     io_reg[0] = 0x80 | (region_code >> 1);
   }
+
+  /* CONTROLLERS */
+  load_param(gamepad, sizeof(gamepad));
 
   /* VDP */
   bufferptr += vdp_context_load(&state[bufferptr]);
@@ -152,6 +158,7 @@ int state_load(unsigned char *state)
     load_param(&m68k.cycles, sizeof(m68k.cycles));
     load_param(&m68k.int_level, sizeof(m68k.int_level));
     load_param(&m68k.stopped, sizeof(m68k.stopped));
+    load_param(&m68k.refresh_cycles, sizeof(m68k.refresh_cycles));
   }
 
   /* Z80 */ 
@@ -200,6 +207,9 @@ int state_save(unsigned char *state)
   memcpy(version,STATE_VERSION,16);
   save_param(version, 16);
 
+  /* SYSTEM */
+  save_param(&pause_b, sizeof(pause_b));
+
   /* GENESIS */
   if ((system_hw & SYSTEM_PBC) == SYSTEM_MD)
   {
@@ -215,7 +225,10 @@ int state_save(unsigned char *state)
 
   /* IO */
   save_param(io_reg, sizeof(io_reg));
-
+  
+  /* CONTROLLERS */
+  save_param(gamepad, sizeof(gamepad));
+  
   /* VDP */
   bufferptr += vdp_context_save(&state[bufferptr]);
 
@@ -251,6 +264,7 @@ int state_save(unsigned char *state)
     save_param(&m68k.cycles, sizeof(m68k.cycles));
     save_param(&m68k.int_level, sizeof(m68k.int_level));
     save_param(&m68k.stopped, sizeof(m68k.stopped));
+    save_param(&m68k.refresh_cycles, sizeof(m68k.refresh_cycles));
   }
 
   /* Z80 */ 

--- a/core/system.c
+++ b/core/system.c
@@ -51,7 +51,7 @@ uint8 system_bios;
 uint32 system_clock;
 int16 SVP_cycles = 800; 
 
-static uint8 pause_b;
+uint8 pause_b;
 static EQSTATE eq[2];
 static int16 llp,rrp;
 

--- a/core/system.h
+++ b/core/system.h
@@ -103,6 +103,7 @@ extern int16 SVP_cycles;
 extern uint8 system_hw;
 extern uint8 system_bios;
 extern uint32 system_clock;
+extern uint8 pause_b;
 
 /* Function prototypes */
 extern int audio_init(int samplerate, double framerate);


### PR DESCRIPTION
This is a continuation of the discussion in #548 and #549

Alright, I kept trying to pinpont the exact cause(s) of the desyncs I observed in my test cases. In the end, just as you said, it was not necessary to make any sweeping changes to the cpu mapping. I don't know what side-effect this change had solved, but it seemed to be a non-issue now I revisited the code.

So in the end I only added 3 things:
- `b_pause` -- Syncs Prince of Persia (Game Gear)
- `gamepad` -- Syncs Another World (Genesis)
- `m68k.refresh_cycles` -- Syncs most of the rest of tests (Sega CD, SVP, SMS)

Of course, adding these seems totally unecessary for casual gameplay. However, as far as my tests go, these changes makes the savestate procedures pretty much bulletproof. 

Thanks for your time yet again
