### PR TITLE
Use the UNLIKELY() macro for cpu hooks

### DIFF
--- a/core/m68k/m68kcpu.c
+++ b/core/m68k/m68kcpu.c
@@ -292,7 +292,7 @@ void m68k_run(unsigned int cycles)
 
 #ifdef HOOK_CPU
     /* Trigger execution hook */
-    if (cpu_hook)
+    if (UNLIKELY(cpu_hook))
       cpu_hook(HOOK_M68K_E, 0, REG_PC, 0);
 #endif
 

--- a/core/m68k/m68kcpu.h
+++ b/core/m68k/m68kcpu.h
@@ -859,7 +859,7 @@ INLINE uint m68ki_read_8(uint address)
   else val = READ_BYTE(temp->base, (address) & 0xffff);
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_R, 1, address, val);
 #endif
 
@@ -879,7 +879,7 @@ INLINE uint m68ki_read_16(uint address)
   else val = *(uint16 *)(temp->base + ((address) & 0xffff));
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_R, 2, address, val);
 #endif
 
@@ -899,7 +899,7 @@ INLINE uint m68ki_read_32(uint address)
   else val = m68k_read_immediate_32(address);
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_R, 4, address, val);
 #endif
 
@@ -913,7 +913,7 @@ INLINE void m68ki_write_8(uint address, uint value)
   m68ki_set_fc(FLAG_S | FUNCTION_CODE_USER_DATA) /* auto-disable (see m68kcpu.h) */
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_W, 1, address, value);
 #endif
 
@@ -930,7 +930,7 @@ INLINE void m68ki_write_16(uint address, uint value)
   m68ki_check_address_error(address, MODE_WRITE, FLAG_S | FUNCTION_CODE_USER_DATA); /* auto-disable (see m68kcpu.h) */
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_W, 2, address, value);
 #endif
 
@@ -947,7 +947,7 @@ INLINE void m68ki_write_32(uint address, uint value)
   m68ki_check_address_error(address, MODE_WRITE, FLAG_S | FUNCTION_CODE_USER_DATA) /* auto-disable (see m68kcpu.h) */
 
 #ifdef HOOK_CPU
-  if (cpu_hook)
+  if (UNLIKELY(cpu_hook))
     cpu_hook(HOOK_M68K_W, 4, address, value);
 #endif
 

--- a/core/macros.h
+++ b/core/macros.h
@@ -53,6 +53,15 @@
 #define ALIGNED_(x) __attribute__ ((aligned(x)))
 #endif
 
+/* Provide the compiler with branch prediction information */
+#if defined(__GNUC__)
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+#else
+#define LIKELY(x) x
+#define UNLIKELY(x) x
+#endif
+
 /* Default CD image file access (read-only) functions */
 /* If you need to override default stdio.h functions with custom filesystem API,
    redefine following macros in platform specific include file (osd.h) or Makefile

--- a/core/vdp_ctrl.c
+++ b/core/vdp_ctrl.c
@@ -2162,7 +2162,7 @@ static void vdp_bus_w(unsigned int data)
       }
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_VRAM_W, 2, addr, data);
 #endif
 
@@ -2211,7 +2211,7 @@ static void vdp_bus_w(unsigned int data)
       }
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_CRAM_W, 2, addr, data);
 #endif
 
@@ -2237,7 +2237,7 @@ static void vdp_bus_w(unsigned int data)
       }
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_VSRAM_W, 2, addr, data);
 #endif
 
@@ -2448,7 +2448,7 @@ static unsigned int vdp_68k_data_r_m5(void)
       data = *(uint16 *)&vram[addr & 0xFFFE];
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_VRAM_R, 2, addr, data);
 #endif
 
@@ -2477,7 +2477,7 @@ static unsigned int vdp_68k_data_r_m5(void)
       data |= (fifo[fifo_idx] & ~0x7FF);
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_VSRAM_R, 2, addr, data);
 #endif
 
@@ -2499,7 +2499,7 @@ static unsigned int vdp_68k_data_r_m5(void)
       data |= (fifo[fifo_idx] & ~0xEEE);
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_CRAM_R, 2, addr, data);
 #endif
 
@@ -2518,7 +2518,7 @@ static unsigned int vdp_68k_data_r_m5(void)
       data |= (fifo[fifo_idx] & ~0xFF);
 
 #ifdef HOOK_CPU
-      if (cpu_hook)
+      if (UNLIKELY(cpu_hook))
         cpu_hook(HOOK_VRAM_R, 2, addr, data);
 #endif
 


### PR DESCRIPTION
Even when HOOK_CPU is defined, actual hooks are assigned not very frequently, so we can speed things up by hinting the compiler what the most common scenario is. Might be useful in other situations but I don't know the code that well.