### PR TITLE
Add Force VDP Mode option

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -132,6 +132,21 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "auto"
    },
    {
+      "genesis_plus_gx_vdp_mode",
+      "Force VDP Mode",
+      NULL,
+      "Overrides the VDP mode to force it to run at either NTSC 60Hz or PAL 50Hz, regardless of system region.",
+      NULL,
+      "system",
+      {
+         { "auto",  "Disabled" },
+         { "60hz",  "NTSC (60Hz)" },
+         { "50hz",  "PAL (50Hz)" },
+         { NULL, NULL },
+      },
+      "auto"
+   },
+   {
       "genesis_plus_gx_bios",
       "System Boot ROM",
       NULL,


### PR DESCRIPTION
Adds https://github.com/libretro/Genesis-Plus-GX/commit/ba9fc37cfa4930311a9c77b1d8a23df0cae95e9a to upstream with an addition update to the option description suggested here:
https://github.com/libretro/Genesis-Plus-GX/issues/358