### PR TITLE
fix OGG Vorbis playback in some Libretro platforms, disable multiple OGG at once on GC/Wii/Wii U libretro

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -243,7 +243,7 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	ENDIANNESS_DEFINES := -DBYTE_ORDER=BIG_ENDIAN -DCPU_IS_BIG_ENDIAN=1 -DWORDS_BIGENDIAN=1
-   PLATFORM_DEFINES := -DGEKKO -mcpu=750 -meabi -mhard-float -DALT_RENDER
+   PLATFORM_DEFINES := -DGEKKO -mcpu=750 -meabi -mhard-float -DALT_RENDER -DDISABLE_MANY_OGG_OPEN_FILES
    PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
    STATIC_LINKING = 1
 

--- a/core/cd_hw/cdd.c
+++ b/core/cd_hw/cdd.c
@@ -155,6 +155,17 @@ static const char extensions[SUPPORTED_EXT][16] =
 
 #if defined(USE_LIBTREMOR) || defined(USE_LIBVORBIS)
 
+#if defined(__LIBRETRO__)
+static int ov_seek64_wrap(void *f,ogg_int64_t off,int whence)
+	{ return cdStreamSeek(f,off,whence); }
+static size_t ov_cdStreamRead(void *buf, size_t sz, size_t n, void *f)
+	{ return cdStreamRead(buf,sz,n,f); }
+static int ov_cdStreamClose(void *f)
+	{ return cdStreamClose(f); }
+static long ov_cdStreamTell(void *f)
+	{ return cdStreamTell(f); }
+static ov_callbacks cb = { ov_cdStreamRead, ov_seek64_wrap, ov_cdStreamClose, ov_cdStreamTell };
+#else
 static int seek64_wrap(void *f,ogg_int64_t off,int whence){
   return cdStreamSeek(f,off,whence);
 }
@@ -166,6 +177,7 @@ static ov_callbacks cb =
   (int (*)(void *))                             cdStreamClose,
   (long (*)(void *))                            cdStreamTell
 };
+#endif
 
 #ifdef DISABLE_MANY_OGG_OPEN_FILES
 static void ogg_free(int i)


### PR DESCRIPTION
Not sure but it seems the libretro VFS implementation/stuff breaks OGG playback in some Libretro platforms (mostly GameCube/Wii/Wii U)...

Also disables multiple OGG files open at once in the libretro cores for GC, Wii, and Wii U, as it could also cause OGG playback issues.

Thanks to @irixxxx for helping with this fix, while we were working on OGG support for PicoDrive.

Fixes https://github.com/ekeeke/Genesis-Plus-GX/issues/590 , https://github.com/libretro/Genesis-Plus-GX/issues/381 , and also probably https://github.com/libretro/Genesis-Plus-GX/issues/220