### PR TITLE
add UNLIKELY() macro to address error emulation

### DIFF
--- a/core/m68k/m68kcpu.h
+++ b/core/m68k/m68kcpu.h
@@ -320,7 +320,7 @@
     }
 
   #define m68ki_check_address_error(ADDR, WRITE_MODE, FC) \
-    if((ADDR)&1) \
+    if(UNLIKELY((ADDR)&1)) \
     { \
       if (m68ki_cpu.aerr_enabled) \
       { \


### PR DESCRIPTION
[Last time](https://github.com/ekeeke/Genesis-Plus-GX/pull/554) we missed this case, sorry.