### PR TITLE
Validate Sega CD savestate track index

### DIFF
--- a/core/cd_hw/cdd.c
+++ b/core/cd_hw/cdd.c
@@ -301,6 +301,12 @@ int cdd_context_load(uint8 *state, char *version)
   cdd.status = tmp8 & 0xf;
   cdd.pending = tmp8 >> 4;
 
+  /* reject invalid current track index */
+  if (index > cdd.toc.last)
+  {
+    return 0;
+  }
+
   /* update current sector */
   cdd.lba = lba;
 


### PR DESCRIPTION
The Sega CD state loader accepted a serialized current-track index and dereferenced it in the mounted disc’s TOC without validating it. A crafted compatible state could read outside the 100-entry track table.

Reject indices outside the mounted TOC before restoring the CD state.